### PR TITLE
Rename plugin to CME Personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,29 @@
-# Cruise Made Easy Post Types and Media Tags
+# Cruise Made Easy - Personas
 
-A WordPress plugin that adds the Customer Persona custom post type and media library tagging functionality.
+A WordPress plugin that adds the Customer Persona custom post type for organizing customer information.
 
 ## Description
 
-Cruise Made Easy Post Types and Media Tags adds a Customer Persona custom post type for organizing customer personas and enhances the WordPress Media Library with a powerful tagging system.
+Cruise Made Easy Personas adds a Customer Persona custom post type for organizing and managing customer personas in your WordPress site.
 
 ### Features
 
 - Creates a Customer Persona custom post type
-- Adds Media Tags taxonomy to WordPress Media Library
-- Provides an enhanced interface for tagging media directly in the Media Library grid view
-- Allows filtering media by tags
+- Provides a structured way to organize customer information
+- Fully compatible with the WordPress block editor
 
 ## Requirements
 
-- WordPress 6.4 or higher
-- PHP 8.2 or higher
+- WordPress 6.7.2 or higher
+- PHP 8.3 or higher
 
 ## Installation
 
-1.  Upload the `cme-cpt-and-taxonomy` folder to the `/wp-content/plugins/` directory
+1.  Upload the `cme-personas` folder to the `/wp-content/plugins/` directory
 2.  Activate the plugin through the 'Plugins' menu in WordPress
-3.  Start using the Customer Persona post type and Media Tags
+3.  Start using the Customer Persona post type
 
 ## Usage
-
-### Media Tags
-
-After activation, you can add tags to your media files:
-
-1.  Go to Media Library
-2.  Hover over an image in grid view to see the tagging interface
-3.  Add tags separated by commas
-4.  Click "Save" to apply the tags
-
-To filter media by tags, use the dropdown filter that appears above the Media Library.
 
 ### Customer Personas
 
@@ -48,21 +36,13 @@ To create a new customer persona:
 
 ## Frequently Asked Questions
 
-### How do I add tags to media?
-
-In the Media Library, hover over an item to see the tagging interface. You can add or remove tags directly from the edit form that appears.
-
-### Can I filter media by tags?
-
-Yes, use the dropdown filter above the Media Library to filter by specific tags.
-
 ### Does this plugin work with Gutenberg?
 
 Yes, the Customer Persona post type is fully compatible with the WordPress block editor (Gutenberg).
 
-### Will this plugin affect my existing media?
+### Can I customize the fields for Customer Personas?
 
-No, this plugin only adds functionality and doesn't alter your existing media files or structure. It simply gives you more ways to organize them.
+The plugin provides a standard WordPress post editing experience. You can use custom fields or extend the functionality with custom blocks.
 
 ## Development
 
@@ -80,6 +60,12 @@ This plugin follows WordPress coding standards and uses modern PHP 8.2 features.
 3.  Submit a pull request
 
 ## Changelog
+
+### 2.0.0
+
+- Major update: Renamed plugin to "Cruise Made Easy Personas"
+- Removed media tags functionality (now available in a separate plugin)
+- Focused exclusively on Customer Persona management
 
 ### 1.0.1
 

--- a/cme-personas.php
+++ b/cme-personas.php
@@ -1,20 +1,20 @@
 <?php
 /**
- * Cruise Made Easy Post Types and Media Tags.
+ * CME Personas.
  *
- * @package     CME_CPT_Taxonomy
+ * @package     CME_Personas
  * @author      Your Name
  * @copyright   2025 Your Name or Company
  * @license     GPL-2.0-or-later
  *
  * @wordpress-plugin
- * Plugin Name: Cruise Made Easy Post Types and Media Tags.
+ * Plugin Name: CME Personas.
  * Plugin URI: https://example.com/plugin.
- * Description: Adds custom post types and a tag taxonomy for media library.
+ * Description: Adds custom persona post type management for Cruise Made Easy.
  * Version: 1.0.0.
  * Author: Your Name.
  * Author URI: https://example.com.
- * Text Domain: cme-cpt-and-taxonomy.
+ * Text Domain: cme-personas.
  * License: GPL v2 or later.
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt.
  * Requires at least: 6.4.
@@ -34,7 +34,7 @@ if ( version_compare( $wp_version, '6.4', '<' ) ) {
 		function () {
 			?>
 		<div class="notice notice-error">
-			<p><?php esc_html_e( 'Cruise Made Easy Post Types and Media Tags requires WordPress version 6.4 or higher.', 'cme-cpt-and-taxonomy' ); ?></p>
+			<p><?php esc_html_e( 'CME Personas requires WordPress version 6.4 or higher.', 'cme-personas' ); ?></p>
 		</div>
 			<?php
 		}
@@ -49,7 +49,7 @@ if ( version_compare( PHP_VERSION, '8.2', '<' ) ) {
 		function () {
 			?>
 		<div class="notice notice-error">
-			<p><?php esc_html_e( 'Cruise Made Easy Post Types and Media Tags requires PHP version 8.2 or higher.', 'cme-cpt-and-taxonomy' ); ?></p>
+			<p><?php esc_html_e( 'CME Personas requires PHP version 8.2 or higher.', 'cme-personas' ); ?></p>
 		</div>
 			<?php
 		}
@@ -75,21 +75,21 @@ require_once CME_PLUGIN_DIR . 'includes/class-plugin.php';
  *
  * @since 1.0.0
  */
-function cme_run_cme_cpt_taxonomy() {
-	$plugin = new CME_CPT_Taxonomy\Plugin();
+function cme_run_cme_personas() {
+	$plugin = new CME_Personas\Plugin();
 	$plugin->run();
 }
-cme_run_cme_cpt_taxonomy();
+cme_run_cme_personas();
 
 // Add activation hook to flush rewrite rules.
 register_activation_hook(
 	CME_PLUGIN_FILE,
 	function () {
 		// Save plugin version.
-		update_option( 'cme_cpt_taxonomy_version', CME_VERSION );
+		update_option( 'cme_personas_version', CME_VERSION );
 
 		// Schedule a rewrite flush.
-		set_transient( 'cme_cpt_taxonomy_flush_rewrite', 1, 30 );
+		set_transient( 'cme_personas_flush_rewrite', 1, 30 );
 	}
 );
 
@@ -97,8 +97,8 @@ register_activation_hook(
 add_action(
 	'admin_init',
 	function () {
-		if ( get_transient( 'cme_cpt_taxonomy_flush_rewrite' ) ) {
-			delete_transient( 'cme_cpt_taxonomy_flush_rewrite' );
+		if ( get_transient( 'cme_personas_flush_rewrite' ) ) {
+			delete_transient( 'cme_personas_flush_rewrite' );
 			flush_rewrite_rules();
 		}
 	}
@@ -110,8 +110,7 @@ add_filter(
 	function ( $links ) {
 		// Add custom action links.
 		$custom_links = [
-			'<a href="' . admin_url( 'edit.php?post_type=persona' ) . '">' . __( 'Personas', 'cme-cpt-and-taxonomy' ) . '</a>',
-			'<a href="' . admin_url( 'edit-tags.php?taxonomy=media_tag&post_type=attachment' ) . '">' . __( 'Media Tags', 'cme-cpt-and-taxonomy' ) . '</a>',
+			'<a href="' . admin_url( 'edit.php?post_type=persona' ) . '">' . __( 'Personas', 'cme-personas' ) . '</a>',
 		];
 
 		return array_merge( $custom_links, $links );

--- a/includes/class-custom-post-types.php
+++ b/includes/class-custom-post-types.php
@@ -3,10 +3,10 @@
  * Custom Post Types registration.
  *
  * @since      1.0.0
- * @package    CME_CPT_Taxonomy
+ * @package    CME_Personas
  */
 
-namespace CME_CPT_Taxonomy;
+namespace CME_Personas;
 
 /**
  * Custom Post Types class.
@@ -14,7 +14,7 @@ namespace CME_CPT_Taxonomy;
  * This class handles registration of custom post types.
  *
  * @since      1.0.0
- * @package    CME_CPT_Taxonomy
+ * @package    CME_Personas
  */
 class Custom_Post_Types {
 	/**
@@ -61,24 +61,24 @@ class Custom_Post_Types {
 			$this->persona_post_type,
 			array(
 				'labels'            => array(
-					'name'                  => _x( 'Customer Personas', 'Post type general name', 'cme-cpt-and-taxonomy' ),
-					'singular_name'         => _x( 'Customer Persona', 'Post type singular name', 'cme-cpt-and-taxonomy' ),
-					'menu_name'             => _x( 'Personas', 'Admin Menu text', 'cme-cpt-and-taxonomy' ),
-					'name_admin_bar'        => _x( 'Customer Persona', 'Add New on Toolbar', 'cme-cpt-and-taxonomy' ),
-					'add_new'               => __( 'Add New', 'cme-cpt-and-taxonomy' ),
-					'add_new_item'          => __( 'Add New Customer Persona', 'cme-cpt-and-taxonomy' ),
-					'new_item'              => __( 'New Customer Persona', 'cme-cpt-and-taxonomy' ),
-					'edit_item'             => __( 'Edit Customer Persona', 'cme-cpt-and-taxonomy' ),
-					'view_item'             => __( 'View Customer Persona', 'cme-cpt-and-taxonomy' ),
-					'all_items'             => __( 'All Customer Personas', 'cme-cpt-and-taxonomy' ),
-					'search_items'          => __( 'Search Customer Personas', 'cme-cpt-and-taxonomy' ),
-					'parent_item_colon'     => __( 'Parent Customer Personas:', 'cme-cpt-and-taxonomy' ),
-					'not_found'             => __( 'No customer personas found.', 'cme-cpt-and-taxonomy' ),
-					'not_found_in_trash'    => __( 'No customer personas found in Trash.', 'cme-cpt-and-taxonomy' ),
-					'featured_image'        => _x( 'Customer Persona Image', 'Overrides the "Featured Image" phrase', 'cme-cpt-and-taxonomy' ),
-					'set_featured_image'    => _x( 'Set persona image', 'Overrides the "Set featured image" phrase', 'cme-cpt-and-taxonomy' ),
-					'remove_featured_image' => _x( 'Remove persona image', 'Overrides the "Remove featured image" phrase', 'cme-cpt-and-taxonomy' ),
-					'use_featured_image'    => _x( 'Use as persona image', 'Overrides the "Use as featured image" phrase', 'cme-cpt-and-taxonomy' ),
+					'name'                  => _x( 'Customer Personas', 'Post type general name', 'cme-personas' ),
+					'singular_name'         => _x( 'Customer Persona', 'Post type singular name', 'cme-personas' ),
+					'menu_name'             => _x( 'Personas', 'Admin Menu text', 'cme-personas' ),
+					'name_admin_bar'        => _x( 'Customer Persona', 'Add New on Toolbar', 'cme-personas' ),
+					'add_new'               => __( 'Add New', 'cme-personas' ),
+					'add_new_item'          => __( 'Add New Customer Persona', 'cme-personas' ),
+					'new_item'              => __( 'New Customer Persona', 'cme-personas' ),
+					'edit_item'             => __( 'Edit Customer Persona', 'cme-personas' ),
+					'view_item'             => __( 'View Customer Persona', 'cme-personas' ),
+					'all_items'             => __( 'All Customer Personas', 'cme-personas' ),
+					'search_items'          => __( 'Search Customer Personas', 'cme-personas' ),
+					'parent_item_colon'     => __( 'Parent Customer Personas:', 'cme-personas' ),
+					'not_found'             => __( 'No customer personas found.', 'cme-personas' ),
+					'not_found_in_trash'    => __( 'No customer personas found in Trash.', 'cme-personas' ),
+					'featured_image'        => _x( 'Customer Persona Image', 'Overrides the "Featured Image" phrase', 'cme-personas' ),
+					'set_featured_image'    => _x( 'Set persona image', 'Overrides the "Set featured image" phrase', 'cme-personas' ),
+					'remove_featured_image' => _x( 'Remove persona image', 'Overrides the "Remove featured image" phrase', 'cme-personas' ),
+					'use_featured_image'    => _x( 'Use as persona image', 'Overrides the "Use as featured image" phrase', 'cme-personas' ),
 				),
 				'public'            => true,
 				'show_ui'           => true,
@@ -106,7 +106,7 @@ class Custom_Post_Types {
 	public function add_persona_meta_boxes(): void {
 		add_meta_box(
 			'persona_gender_images',
-			__( 'Gender-Specific Images', 'cme-cpt-and-taxonomy' ),
+			__( 'Gender-Specific Images', 'cme-personas' ),
 			array( $this, 'render_persona_gender_images_metabox' ),
 			$this->persona_post_type,
 			'normal',
@@ -151,16 +151,16 @@ class Custom_Post_Types {
 			}
 		</style>
 
-		<p><?php esc_html_e( 'Select gender-specific images for this persona.', 'cme-cpt-and-taxonomy' ); ?></p>
+		<p><?php esc_html_e( 'Select gender-specific images for this persona.', 'cme-personas' ); ?></p>
 
 		<div class="persona-gender-image">
-			<label><strong><?php esc_html_e( 'Male Image', 'cme-cpt-and-taxonomy' ); ?></strong></label><br>
+			<label><strong><?php esc_html_e( 'Male Image', 'cme-personas' ); ?></strong></label><br>
 			<input type="hidden" name="persona_image_male" id="persona_image_male" value="<?php echo esc_attr( $male_image_id ); ?>">
 			<button type="button" class="button persona-upload-image" data-target="persona_image_male">
-				<?php esc_html_e( 'Select Image', 'cme-cpt-and-taxonomy' ); ?>
+				<?php esc_html_e( 'Select Image', 'cme-personas' ); ?>
 			</button>
 			<button type="button" class="button persona-remove-image" data-target="persona_image_male" <?php echo empty( $male_image_id ) ? 'style="display:none;"' : ''; ?>>
-				<?php esc_html_e( 'Remove Image', 'cme-cpt-and-taxonomy' ); ?>
+				<?php esc_html_e( 'Remove Image', 'cme-personas' ); ?>
 			</button>
 			<div class="persona-image-preview" id="persona_image_male_preview">
 				<?php if ( $male_image_id ) : ?>
@@ -170,13 +170,13 @@ class Custom_Post_Types {
 		</div>
 
 		<div class="persona-gender-image">
-			<label><strong><?php esc_html_e( 'Female Image', 'cme-cpt-and-taxonomy' ); ?></strong></label><br>
+			<label><strong><?php esc_html_e( 'Female Image', 'cme-personas' ); ?></strong></label><br>
 			<input type="hidden" name="persona_image_female" id="persona_image_female" value="<?php echo esc_attr( $female_image_id ); ?>">
 			<button type="button" class="button persona-upload-image" data-target="persona_image_female">
-				<?php esc_html_e( 'Select Image', 'cme-cpt-and-taxonomy' ); ?>
+				<?php esc_html_e( 'Select Image', 'cme-personas' ); ?>
 			</button>
 			<button type="button" class="button persona-remove-image" data-target="persona_image_female" <?php echo empty( $female_image_id ) ? 'style="display:none;"' : ''; ?>>
-				<?php esc_html_e( 'Remove Image', 'cme-cpt-and-taxonomy' ); ?>
+				<?php esc_html_e( 'Remove Image', 'cme-personas' ); ?>
 			</button>
 			<div class="persona-image-preview" id="persona_image_female_preview">
 				<?php if ( $female_image_id ) : ?>
@@ -186,13 +186,13 @@ class Custom_Post_Types {
 		</div>
 
 		<div class="persona-gender-image">
-			<label><strong><?php esc_html_e( 'Indeterminate Gender Image', 'cme-cpt-and-taxonomy' ); ?></strong></label><br>
+			<label><strong><?php esc_html_e( 'Indeterminate Gender Image', 'cme-personas' ); ?></strong></label><br>
 			<input type="hidden" name="persona_image_indeterminate" id="persona_image_indeterminate" value="<?php echo esc_attr( $indeterminate_image_id ); ?>">
 			<button type="button" class="button persona-upload-image" data-target="persona_image_indeterminate">
-				<?php esc_html_e( 'Select Image', 'cme-cpt-and-taxonomy' ); ?>
+				<?php esc_html_e( 'Select Image', 'cme-personas' ); ?>
 			</button>
 			<button type="button" class="button persona-remove-image" data-target="persona_image_indeterminate" <?php echo empty( $indeterminate_image_id ) ? 'style="display:none;"' : ''; ?>>
-				<?php esc_html_e( 'Remove Image', 'cme-cpt-and-taxonomy' ); ?>
+				<?php esc_html_e( 'Remove Image', 'cme-personas' ); ?>
 			</button>
 			<div class="persona-image-preview" id="persona_image_indeterminate_preview">
 				<?php if ( $indeterminate_image_id ) : ?>

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -3,10 +3,10 @@
  * The core plugin class.
  *
  * @since      1.0.0
- * @package    CME_CPT_Taxonomy
+ * @package    CME_Personas
  */
 
-namespace CME_CPT_Taxonomy;
+namespace CME_Personas;
 
 /**
  * The core plugin class.
@@ -15,7 +15,7 @@ namespace CME_CPT_Taxonomy;
  * public-facing site hooks.
  *
  * @since      1.0.0
- * @package    CME_CPT_Taxonomy
+ * @package    CME_Personas
  */
 class Plugin {
 
@@ -105,7 +105,7 @@ class Plugin {
 	 */
 	public function load_textdomain(): void {
 		load_plugin_textdomain(
-			'cme-cpt-and-taxonomy',
+			'cme-personas',
 			false,
 			dirname( plugin_basename( CME_PLUGIN_FILE ) ) . '/languages/'
 		);
@@ -153,12 +153,11 @@ class Plugin {
 
 		?>
 		<div class="notice notice-info is-dismissible cme-welcome-notice">
-			<h3><?php esc_html_e( 'Thank you for installing Cruise Made Easy Post Types and Media Tags!', 'cme-cpt-and-taxonomy' ); ?></h3>
-			<p><?php esc_html_e( 'You can now start using Customer Personas and organize your Media Library with tags.', 'cme-cpt-and-taxonomy' ); ?></p>
+			<h3><?php esc_html_e( 'Thank you for installing Cruise Made Easy Personas!', 'cme-personas' ); ?></h3>
+			<p><?php esc_html_e( 'You can now start using Customer Personas.', 'cme-personas' ); ?></p>
 			<p>
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=persona' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Manage Personas', 'cme-cpt-and-taxonomy' ); ?></a>
-				<a href="<?php echo esc_url( admin_url( 'upload.php' ) ); ?>" class="button"><?php esc_html_e( 'Go to Media Library', 'cme-cpt-and-taxonomy' ); ?></a>
-				<a href="#" class="cme-dismiss-welcome button" data-nonce="<?php echo esc_attr( wp_create_nonce( 'cme_dismiss_welcome' ) ); ?>"><?php esc_html_e( 'Dismiss', 'cme-cpt-and-taxonomy' ); ?></a>
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=persona' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Manage Personas', 'cme-personas' ); ?></a>
+				<a href="#" class="cme-dismiss-welcome button" data-nonce="<?php echo esc_attr( wp_create_nonce( 'cme_dismiss_welcome' ) ); ?>"><?php esc_html_e( 'Dismiss', 'cme-personas' ); ?></a>
 			</p>
 		</div>
 		<script>


### PR DESCRIPTION
## Changes
This PR implements the renaming of the plugin from 'CME Post Types and Media Tags' to 'CME Personas'.

### Major Changes
- Renamed plugin to 'CME Personas'
- Removed media tags functionality (now in separate plugin)
- Updated namespace to CME_Personas
- Updated text domain to 'cme-personas'
- Renamed main plugin file to cme-personas.php
- Updated documentation

### Technical Updates
- Updated PHP requirement to 8.3
- Updated WordPress requirement to 6.7.2
- Updated README.md with new plugin information
- Removed all media tags related code and documentation

### Testing
- [ ] Verify plugin activates correctly with new name
- [ ] Confirm Customer Persona functionality works as expected
- [ ] Check all namespace references are updated
- [ ] Verify text domain is consistently used
- [ ] Confirm README.md accurately reflects current functionality