### PR TITLE
Fix class loading and PHP 8 compatibility issues (v1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the CME Personas plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2025-03-13
+
+### Fixed
+
+- Fixed "Class 'CME_Personas\Persona_Manager' not found" error by adding proper class dependencies
+- Fixed PHP 8 compatibility issues with parameter order in set_content methods
+- Fixed "headers already sent" warnings caused by deprecation notices
+
 ## [1.4.0] - 2025-03-13
 
 ### Added

--- a/cme-personas.php
+++ b/cme-personas.php
@@ -11,7 +11,7 @@
  * Plugin Name:       CME Personas
  * Plugin URI:        https://cruisemadeeasy.com/plugins/cme-personas
  * Description:       Customer persona management system with content personalization.
- * Version:           1.4.0
+ * Version:           1.4.1
  * Requires at least: 5.9
  * Requires PHP:      7.4
  * Author:            Cruise Made Easy
@@ -27,7 +27,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // Define plugin constants.
-define( 'CME_PERSONAS_VERSION', '1.4.0' );
+define( 'CME_PERSONAS_VERSION', '1.4.1' );
 define( 'CME_PERSONAS_FILE', __FILE__ );
 define( 'CME_PERSONAS_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CME_PERSONAS_URL', plugin_dir_url( __FILE__ ) );

--- a/includes/class-persona-content.php
+++ b/includes/class-persona-content.php
@@ -116,13 +116,13 @@ class Persona_Content {
 	 *
 	 * @since     1.1.0
 	 * @param     int    $entity_id       The entity ID (e.g., post ID).
-	 * @param     string $entity_type     The entity type (default: 'post').
 	 * @param     string $content_field   The content field name.
 	 * @param     mixed  $content         The content to store.
 	 * @param     string $persona_id      The persona ID.
+	 * @param     string $entity_type     The entity type (default: 'post').
 	 * @return    bool                    Whether the content was set successfully.
 	 */
-	public function set_content( $entity_id, $entity_type = 'post', $content_field, $content, $persona_id ) {
+	public function set_content( $entity_id, $content_field, $content, $persona_id, $entity_type = 'post' ) {
 		// Don't store content for the default persona.
 		if ( 'default' === $persona_id ) {
 			return false;

--- a/includes/class-personas-api.php
+++ b/includes/class-personas-api.php
@@ -260,14 +260,14 @@ class Personas_API {
 	 *
 	 * @since     1.1.0
 	 * @param     int    $entity_id       The entity ID (e.g., post ID).
-	 * @param     string $entity_type     The entity type (default: 'post').
 	 * @param     string $content_field   The content field name.
 	 * @param     mixed  $content         The content to store.
 	 * @param     string $persona_id      The persona ID.
+	 * @param     string $entity_type     The entity type (default: 'post').
 	 * @return    bool                    Whether the content was set successfully.
 	 */
-	public function set_content( $entity_id, $entity_type = 'post', $content_field, $content, $persona_id ) {
-		return $this->persona_content->set_content( $entity_id, $entity_type, $content_field, $content, $persona_id );
+	public function set_content( $entity_id, $content_field, $content, $persona_id, $entity_type = 'post' ) {
+		return $this->persona_content->set_content( $entity_id, $content_field, $content, $persona_id, $entity_type );
 	}
 
 	/**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -81,6 +81,9 @@ class Plugin {
 		require_once CME_PLUGIN_DIR . 'includes/class-dashboard.php';
 		require_once CME_PLUGIN_DIR . 'includes/class-shortcodes.php';
 		require_once CME_PLUGIN_DIR . 'includes/class-settings.php';
+		require_once CME_PLUGIN_DIR . 'includes/class-persona-manager.php';
+		require_once CME_PLUGIN_DIR . 'includes/class-persona-content.php';
+		require_once CME_PLUGIN_DIR . 'includes/class-personas-api.php';
 
 		// Load frontend class to ensure shortcodes are registered.
 		if ( file_exists( CME_PLUGIN_DIR . 'includes/class-frontend.php' ) ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -82,8 +82,8 @@ class Plugin {
 		require_once CME_PLUGIN_DIR . 'includes/class-shortcodes.php';
 		require_once CME_PLUGIN_DIR . 'includes/class-settings.php';
 
-		// Load frontend class to ensure shortcodes are registered
-		if (file_exists(CME_PLUGIN_DIR . 'includes/class-frontend.php')) {
+		// Load frontend class to ensure shortcodes are registered.
+		if ( file_exists( CME_PLUGIN_DIR . 'includes/class-frontend.php' ) ) {
 			require_once CME_PLUGIN_DIR . 'includes/class-frontend.php';
 		}
 	}
@@ -101,8 +101,8 @@ class Plugin {
 		$this->shortcodes        = new Shortcodes();
 		$this->settings          = new Settings();
 
-		// Make sure Frontend is initialized if it exists
-		if (class_exists('\\CME_Personas\\Frontend')) {
+		// Make sure Frontend is initialized if it exists.
+		if ( class_exists( '\\CME_Personas\\Frontend' ) ) {
 			Frontend::get_instance();
 		}
 	}
@@ -134,7 +134,7 @@ class Plugin {
 		$this->shortcodes->register();
 		$this->settings->register();
 
-		// Make sure the integrator is initialized early
+		// Make sure the integrator is initialized early.
 		\CME_Personas\Persona_Integrator::get_instance();
 
 		// Register AJAX handler for welcome notice.


### PR DESCRIPTION
This PR fixes two critical issues:

1. Fixed 'Class not found' error by adding proper dependencies in the Plugin class:
   - Added proper loading of Persona_Manager, Persona_Content, and Personas_API classes

2. Fixed PHP 8 compatibility warnings:
   - Corrected parameter order in set_content methods in both Persona_Content and Personas_API classes
   - Required parameters now come before optional parameters

Also updated version to 1.4.1 and added entry to the CHANGELOG.

This is a patch release to fix production issues.