### PR TITLE
Refactor: Remove MetaSlider-specific code and deprecate entity-based content system

### DIFF
--- a/docs/architecture/IMPLEMENTATION_COMPARISON.md
+++ b/docs/architecture/IMPLEMENTATION_COMPARISON.md
@@ -1,0 +1,469 @@
+# Persona Implementation Approaches: Detailed Comparison
+
+This document provides a comprehensive analysis of two primary approaches for implementing persona-based content delivery in the Cruise Made Easy plugin, with a focus on performance, architecture, and integration with edge caching.
+
+## Table of Contents
+
+- [Persona Implementation Approaches: Detailed Comparison](#persona-implementation-approaches-detailed-comparison)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Option 1: Server-Side Persona Detection with Edge Caching](#option-1-server-side-persona-detection-with-edge-caching)
+    - [Technical Implementation Details](#technical-implementation-details)
+      - [WordPress/PHP Backend](#wordpressphp-backend)
+      - [Cloudflare Configuration](#cloudflare-configuration)
+    - [Performance Characteristics](#performance-characteristics)
+    - [Scalability Factors](#scalability-factors)
+    - [Specific Challenges](#specific-challenges)
+  - [Option 3: Edge-Worker Persona Application](#option-3-edge-worker-persona-application)
+    - [Technical Implementation Details](#technical-implementation-details-1)
+      - [WordPress/PHP Backend](#wordpressphp-backend-1)
+      - [Cloudflare Worker Implementation](#cloudflare-worker-implementation)
+    - [Performance Characteristics](#performance-characteristics-1)
+    - [Scalability Factors](#scalability-factors-1)
+    - [Specific Challenges](#specific-challenges-1)
+  - [Data Flow Comparison with 'easy-breezy' Example](#data-flow-comparison-with-easy-breezy-example)
+    - [Option 1: Server-Side Flow](#option-1-server-side-flow)
+    - [Option 3: Edge-Worker Flow](#option-3-edge-worker-flow)
+  - [Decision Factors Summary](#decision-factors-summary)
+
+## Introduction
+
+Both approaches assume that the Personas plugin handles core persona management, while the Cruise Made Easy plugin needs to integrate with this system to deliver personalized cruise content. The comparison focuses on technical implementation, performance, and integration with edge caching solutions like Cloudflare.
+
+## Option 1: Server-Side Persona Detection with Edge Caching
+
+### Technical Implementation Details
+
+#### WordPress/PHP Backend
+
+1. **GTM Integration Layer**:
+
+    ```php
+    function cme_detect_persona_from_gtm() {
+      // Read from $_COOKIE or GTM dataLayer variables
+      $persona = isset($_COOKIE['_gtm_persona']) ? sanitize_key($_COOKIE['_gtm_persona']) : null;
+
+      // Validate against allowed personas
+      if (!in_array($persona, ['default', 'easy-breezy', 'luxe', 'thrill-seeker'])) {
+        $persona = 'default';
+      }
+
+      return apply_filters('cme_current_persona', $persona);
+    }
+    ```
+
+2. **Pre-Query Content Filtering**:
+
+    ```php
+    function cme_filter_query_for_persona($query) {
+      if (!is_admin() && $query->is_main_query()) {
+        $persona = cme_detect_persona_from_gtm();
+
+        // Add meta query to filter content
+        $query->set('meta_query', [
+          [
+            'key' => '_cme_persona',
+            'value' => [$persona, 'default'],
+            'compare' => 'IN'
+          ]
+        ]);
+      }
+      return $query;
+    }
+    add_action('pre_get_posts', 'cme_filter_query_for_persona');
+    ```
+
+3. **Content Storage Strategy**:
+
+    - Store persona-specific content as post meta
+    - Create separate posts for each persona variation with shared ID relationship
+    - Use custom database tables optimized for persona lookups
+
+4. **Cache Headers Management**:
+
+    ```php
+    function cme_set_persona_cache_headers() {
+      $persona = cme_detect_persona_from_gtm();
+
+      // Set Cloudflare cache headers
+      header('Cache-Tag: persona-' . $persona);
+
+      // Set Vary header to ensure proper caching
+      header('Vary: Cookie');
+    }
+    add_action('send_headers', 'cme_set_persona_cache_headers');
+    ```
+
+#### Cloudflare Configuration
+
+1. **Cache Rules**:
+
+    - Create page rules that cache based on Cookie values
+    - Configure Edge Cache TTL appropriate for content update frequency
+    - Set up cache key modification to include persona information
+
+2. **Example Cloudflare Page Rule**:
+
+    ```yaml
+    URL: *cruisemadeeasy.com/*
+    Settings:
+      - Cache Level: Everything
+      - Edge Cache TTL: 2 hours
+      - Cache Key: Include Cookie: _gtm_persona
+    ```
+
+### Performance Characteristics
+
+1. **Server Load**:
+
+    - Higher than client-side approach because WordPress processes each persona variation separately
+    - Lower than non-cached approaches since edges serve most requests
+    - Database queries are optimized to fetch only relevant persona content
+
+2. **TTFB (Time To First Byte)**:
+
+    - 20-40ms for cached edge responses
+    - 200-800ms for cache misses requiring origin fetch
+    - Subsequent visits are extremely fast with pre-rendered correct content
+
+3. **Bandwidth Usage**:
+    - Optimal: only requested persona content is transferred
+    - Typical page size reduction: 60-75% compared to multi-persona page
+
+### Scalability Factors
+
+- **Content Volume Scale**: Excellent - each request only processes relevant content
+- **Traffic Scale**: Excellent - most requests served from edge
+- **Author Experience**: Good - authors need to be aware of content variations
+- **Development Complexity**: Moderate - requires careful database design and query optimization
+
+### Specific Challenges
+
+1. **Cache Purging Strategy**:
+   When content for a specific persona is updated, you need a targeted cache invalidation strategy:
+
+    ```php
+    function cme_purge_persona_cache($post_id, $post) {
+      $personas = ['default', 'easy-breezy', 'luxe', 'thrill-seeker'];
+
+      foreach ($personas as $persona) {
+        if (has_persona_content($post_id, $persona)) {
+          // Purge specific persona cache
+          cloudflare_purge_cache_tag("persona-{$persona}");
+        }
+      }
+    }
+    add_action('save_post', 'cme_purge_persona_cache', 10, 2);
+    ```
+
+2. **GTM Reliability**:
+   GTM may not always be available on first request. A robust fallback mechanism is needed:
+
+    ```php
+    function cme_get_persona_with_fallback() {
+      $persona = cme_detect_persona_from_gtm();
+
+      // If no persona detected, check URL params
+      if ($persona === 'default' && isset($_GET['persona'])) {
+        $persona = sanitize_key($_GET['persona']);
+      }
+
+      // If still not set or invalid, check user meta if logged in
+      if (!in_array($persona, ['easy-breezy', 'luxe', 'thrill-seeker'])) {
+        if (is_user_logged_in()) {
+          $user_persona = get_user_meta(get_current_user_id(), 'preferred_persona', true);
+          if (!empty($user_persona)) {
+            $persona = $user_persona;
+          }
+        }
+      }
+
+      return $persona;
+    }
+    ```
+
+## Option 3: Edge-Worker Persona Application
+
+### Technical Implementation Details
+
+#### WordPress/PHP Backend
+
+1. **Content Delivery Structure**:
+
+    ```php
+    function cme_wrap_content_with_persona_markers($content) {
+      // Get all persona variations for this content
+      $default_content = $content;
+      $easy_breezy = get_post_meta(get_the_ID(), '_cme_persona_easy_breezy_content', true);
+      $luxe = get_post_meta(get_the_ID(), '_cme_persona_luxe_content', true);
+      $thrill = get_post_meta(get_the_ID(), '_cme_persona_thrill_content', true);
+
+      // Build HTML with all variations
+      $html = '';
+      $html .= '<div data-persona="default">' . $default_content . '</div>';
+
+      if (!empty($easy_breezy)) {
+        $html .= '<div data-persona="easy-breezy">' . $easy_breezy . '</div>';
+      }
+
+      if (!empty($luxe)) {
+        $html .= '<div data-persona="luxe">' . $luxe . '</div>';
+      }
+
+      if (!empty($thrill)) {
+        $html .= '<div data-persona="thrill-seeker">' . $thrill . '</div>';
+      }
+
+      return $html;
+    }
+    add_filter('the_content', 'cme_wrap_content_with_persona_markers');
+    ```
+
+2. **Cache Headers for Edge Worker**:
+
+    ```php
+    function cme_add_edge_compatible_headers() {
+      // Add custom header to signal persona content to edge
+      header('X-Has-Persona-Content: true');
+
+      // Set cache control appropriately
+      header('Cache-Control: public, max-age=3600');
+    }
+    add_action('send_headers', 'cme_add_edge_compatible_headers');
+    ```
+
+#### Cloudflare Worker Implementation
+
+1. **Worker JavaScript Code**:
+
+    ```javascript
+    addEventListener("fetch", (event) => {
+     event.respondWith(handleRequest(event.request));
+    });
+
+    async function handleRequest(request) {
+     // Extract persona from cookies or other sources
+     const persona = getPersonaFromRequest(request) || "default";
+
+     // Get the response from origin or cache
+     const response = await fetch(request);
+
+     // Check if this page has persona content
+     const hasPersonaContent = response.headers.get("X-Has-Persona-Content");
+
+     if (hasPersonaContent !== "true") {
+      // No persona content, return response as is
+      return response;
+     }
+
+     // Get the HTML text
+     const html = await response.text();
+
+     // Process the HTML for this persona
+     const processedHtml = processHtmlForPersona(html, persona);
+
+     // Create a new response
+     const newResponse = new Response(processedHtml, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+     });
+
+     // Add cache headers for this persona
+     newResponse.headers.set("Cache-Tag", `persona-${persona}`);
+
+     return newResponse;
+    }
+
+    function processHtmlForPersona(html, persona) {
+     // Simple regex approach (actual implementation would use HTML parser)
+     const regex = new RegExp(
+      `<div data-persona="${persona}">([\\s\\S]*?)<\/div>`,
+      "g",
+     );
+     let processedHtml = html;
+
+     // Remove all persona containers
+     processedHtml = processedHtml.replace(
+      /<div data-persona="[^"]*">[\s\S]*?<\/div>/g,
+      "",
+     );
+
+     // Find all content for this persona
+     const matches = [...html.matchAll(regex)];
+
+     // Replace back the content for this persona
+     matches.forEach((match) => {
+      // Find position to insert content by looking for markers
+      // This is a simplified approach - real implementation would be more robust
+      processedHtml = processedHtml.replace(
+       "<!-- PERSONA_CONTENT_MARKER -->",
+       match[1],
+      );
+     });
+
+     return processedHtml;
+    }
+
+    function getPersonaFromRequest(request) {
+     // Get cookies from request
+     const cookieHeader = request.headers.get("Cookie") || "";
+     const cookies = cookieHeader.split(";").reduce((obj, c) => {
+      const [key, value] = c.trim().split("=");
+      obj[key] = value;
+      return obj;
+     }, {});
+
+     return cookies["_gtm_persona"];
+    }
+    ```
+
+2. **Enhanced HTML Parser**:
+   For production, you'd want to use a proper HTML parser rather than regex:
+
+    ```javascript
+    // Using HTMLRewriter (Cloudflare's recommended approach)
+    async function handleRequest(request) {
+     const persona = getPersonaFromRequest(request) || "default";
+     const response = await fetch(request);
+
+     if (response.headers.get("X-Has-Persona-Content") !== "true") {
+      return response;
+     }
+
+     return new HTMLRewriter()
+      .on("div[data-persona]", {
+       element(el) {
+        const elPersona = el.getAttribute("data-persona");
+
+        // If this isn't for our persona, remove it
+        if (elPersona !== persona && elPersona !== "default") {
+         el.remove();
+        } else {
+         // Keep the content but remove the data-persona attribute
+         el.removeAttribute("data-persona");
+        }
+       },
+      })
+      .transform(response);
+    }
+    ```
+
+### Performance Characteristics
+
+1. **Server Load**:
+
+    - Lower than Option 1 because the same content (all personas) is served for all requests
+    - Database access pattern is simpler (no complex persona filtering)
+    - WordPress does more work upfront generating all variations
+
+2. **TTFB (Time To First Byte)**:
+
+    - 50-70ms for edge-processed cached responses
+    - 250-850ms for cache misses requiring origin fetch
+    - Slight processing overhead for HTML transformation at the edge
+
+3. **Bandwidth Usage (Origin to Edge)**:
+    - Higher than Option 1: all persona content is transferred to edge
+    - Typical multiplier: 2.5-4x the size of a single-persona page
+    - Bandwidth from edge to client remains optimal
+
+### Scalability Factors
+
+- **Content Volume Scale**: Good - edge handles transformation of increasing content volumes
+- **Traffic Scale**: Excellent - most requests served from edge
+- **Author Experience**: Excellent - content variations are managed in one place
+- **Development Complexity**: Higher - requires Cloudflare Worker expertise
+
+### Specific Challenges
+
+1. **HTML Parsing Complexity**:
+   HTML transformation at edge requires careful handling of nested structures and special cases:
+
+    ```javascript
+    // Handle edge cases with nested persona content
+    .on('div[data-persona] div[data-persona]', {
+      element(el) {
+        // Handle nested persona markers
+        const parent = el.parentElement?.getAttribute('data-persona');
+        const current = el.getAttribute('data-persona');
+
+        // Complex rules for nested persona content...
+      }
+    })
+    ```
+
+2. **Worker Resource Limits**:
+   Cloudflare Workers have CPU time limits. For very large pages:
+
+    ```javascript
+    // Implement streaming processing for large pages
+    async function processLargePage(response, persona) {
+     const { readable, writable } = new TransformStream();
+
+     // Create a streaming HTML processor
+     const htmlProcessor = new HTMLProcessor(persona);
+
+     // Process the stream
+     response.body
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(htmlProcessor)
+      .pipeThrough(new TextEncoderStream())
+      .pipeTo(writable);
+
+     return new Response(readable, response);
+    }
+    ```
+
+## Data Flow Comparison with 'easy-breezy' Example
+
+### Option 1: Server-Side Flow
+
+1. User with GTM tag 'easy-breezy' visits a Caribbean cruise page
+2. Request hits Cloudflare edge
+3. Edge reads `_gtm_persona=easy-breezy` cookie
+4. **If cached**: Edge serves pre-rendered 'easy-breezy' version (DONE)
+5. **If not cached**: Request goes to WordPress with cookie
+6. WordPress reads cookie, sets `$current_persona = 'easy-breezy'`
+7. WordPress queries cruise content: `SELECT * FROM posts JOIN postmeta WHERE post_id=123 AND meta_key='_cme_persona' AND meta_value='easy-breezy'`
+8. If no easy-breezy content found, falls back to default
+9. WordPress renders ONLY relevant content
+10. Response sent to Cloudflare, which caches it with persona key
+11. User receives page with only 'easy-breezy' content
+
+### Option 3: Edge-Worker Flow
+
+1. User with GTM tag 'easy-breezy' visits a Caribbean cruise page
+2. Request hits Cloudflare edge
+3. Edge reads `_gtm_persona=easy-breezy` cookie
+4. **If cached**: Edge serves pre-transformed 'easy-breezy' version (DONE)
+5. **If not cached**: Request goes to WordPress (no persona info needed)
+6. WordPress renders page with ALL persona variations in it:
+
+    ```html
+    <div data-persona="default">Default cruise description...</div>
+    <div data-persona="easy-breezy">Relaxed, simple cruise description...</div>
+    <div data-persona="luxe">
+     Premium cruise description with luxury details...
+    </div>
+    <!-- more content with persona variations -->
+    ```
+
+7. Response returns to Cloudflare edge
+8. Edge Worker processes HTML, keeping only 'easy-breezy' and fallback 'default' content
+9. Transformed HTML is cached at edge with persona key
+10. User receives page with only 'easy-breezy' content
+
+## Decision Factors Summary
+
+| Factor                  | Option 1: Server-Side                               | Option 3: Edge-Worker                               |
+| ----------------------- | --------------------------------------------------- | --------------------------------------------------- |
+| **Development Effort**  | Moderate PHP/WordPress development                  | PHP development + Cloudflare Worker expertise       |
+| **Content Management**  | Standard WordPress editing with persona meta fields | Same WordPress editing experience                   |
+| **Origin Bandwidth**    | Lower (only requested persona sent)                 | Higher (all personas sent to edge)                  |
+| **Origin Server Load**  | Moderate (persona-specific DB queries)              | Lower (simpler queries, more content)               |
+| **Page Size to Client** | Optimal - only contains requested persona           | Optimal - transformed at edge                       |
+| **Cache Efficiency**    | Very good - separate cache entries per persona      | Very good - separate transformed cache entries      |
+| **Time to Market**      | Faster - uses WordPress-native techniques           | Slightly longer - requires edge worker development  |
+| **Maintenance**         | Concentrated in WordPress                           | Split between WordPress and Cloudflare              |
+| **Flexibility**         | Good - easy to add new processing in WordPress      | Excellent - processing can happen at edge or origin |

--- a/docs/architecture/PLUGIN_IMPLEMENTATION.md
+++ b/docs/architecture/PLUGIN_IMPLEMENTATION.md
@@ -1,0 +1,949 @@
+# Personas Plugin Implementation Plan
+
+This document outlines the complete implementation plan for creating a dedicated WordPress Personas plugin that provides persona-based content functionality. This plugin will be separate from but integrated with the Cruise Made Easy plugin.
+
+## Table of Contents
+
+- [Personas Plugin Implementation Plan](#personas-plugin-implementation-plan)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Plugin Architecture](#plugin-architecture)
+  - [Phase 1: Core Infrastructure](#phase-1-core-infrastructure)
+    - [Tasks](#tasks)
+    - [Deliverables](#deliverables)
+    - [Core Classes](#core-classes)
+      - [Persona Manager Class](#persona-manager-class)
+      - [Persona Content Class](#persona-content-class)
+  - [Phase 2: Admin UI](#phase-2-admin-ui)
+    - [Tasks](#tasks-1)
+    - [Deliverables](#deliverables-1)
+    - [Admin UI Implementation](#admin-ui-implementation)
+      - [Admin Class](#admin-class)
+
+## Overview
+
+The Personas plugin will provide a comprehensive system for creating and managing persona-specific content across any WordPress site. It will use structured object storage with post meta, and feature a user-friendly editing interface integrated with the Gutenberg block editor.
+
+Key features:
+
+- Persona detection from GTM/cookies
+- Content storage and retrieval system
+- Admin UI for managing persona content
+- Frontend content replacement
+- Optional Redis caching for performance
+
+## Plugin Architecture
+
+The plugin will follow WordPress best practices with a modular architecture:
+
+```php
+wp-content/plugins/personas/
+├── personas.php                    # Main plugin file
+├── includes/                       # Core functionality
+│   ├── class-personas.php          # Main plugin class
+│   ├── class-activator.php         # Activation hooks
+│   ├── class-deactivator.php       # Deactivation hooks
+│   ├── class-persona-manager.php   # Persona management
+│   ├── class-persona-content.php   # Content storage/retrieval
+│   └── class-persona-cache.php     # Optional Redis caching
+├── admin/                          # Admin functionality
+│   ├── class-personas-admin.php    # Admin functionality
+│   ├── js/
+│   │   └── personas-admin.js       # Admin JavaScript
+│   ├── css/
+│   │   └── personas-admin.css      # Admin styles
+│   └── partials/                   # Admin view templates
+├── public/                         # Frontend functionality
+│   ├── class-personas-public.php   # Public functionality
+│   ├── js/
+│   │   └── personas-public.js      # Public JavaScript
+│   └── css/
+│       └── personas-public.css     # Public styles
+└── languages/                      # Internationalization
+```
+
+## Phase 1: Core Infrastructure
+
+### Tasks
+
+1. **Create Plugin Scaffold**
+
+    - Set up plugin directory structure
+    - Create main plugin file with metadata
+    - Implement activation/deactivation hooks
+
+2. **Create Persona Management Class**
+
+    - Define available personas
+    - Implement persona detection from GTM/cookies
+    - Add functions to get/set current persona
+
+3. **Implement Storage System**
+    - Create functions to save/retrieve persona variations
+    - Define schema for structured content storage
+    - Add metadata registration for persona content
+
+### Deliverables
+
+- Complete plugin scaffold
+- Core classes for persona management
+- Content storage and retrieval system
+
+### Core Classes
+
+#### Persona Manager Class
+
+```php
+/**
+ * Class Personas_Manager
+ *
+ * Handles persona detection, management, and context.
+ */
+class Personas_Manager {
+    /**
+     * Singleton instance.
+     *
+     * @var Personas_Manager
+     */
+    private static $instance = null;
+
+    /**
+     * Available personas.
+     *
+     * @var array
+     */
+    private $personas = [];
+
+    /**
+     * Current persona.
+     *
+     * @var string
+     */
+    private $current_persona = 'default';
+
+    /**
+     * Get singleton instance.
+     *
+     * @return Personas_Manager
+     */
+    public static function get_instance() {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    private function __construct() {
+        // Load available personas
+        $this->load_personas();
+
+        // Detect current persona
+        add_action('init', array($this, 'detect_persona'), 5);
+    }
+
+    /**
+     * Load available personas.
+     */
+    private function load_personas() {
+        // Default personas
+        $this->personas = [
+            'default' => __('Default', 'personas'),
+            'easy-breezy' => __('Easy-Breezy Cruiser', 'personas'),
+            'luxe' => __('Luxe Seafarer', 'personas'),
+            'thrill-seeker' => __('Thrill Seeker', 'personas')
+        ];
+
+        // Allow modification via filter
+        $this->personas = apply_filters('personas_available_personas', $this->personas);
+    }
+
+    /**
+     * Get available personas.
+     *
+     * @return array
+     */
+    public function get_available_personas() {
+        return $this->personas;
+    }
+
+    /**
+     * Detect current persona from GTM/cookies/URL.
+     */
+    public function detect_persona() {
+        $persona = 'default';
+
+        // Try cookie first
+        if (isset($_COOKIE['_gtm_persona'])) {
+            $cookie_persona = sanitize_key($_COOKIE['_gtm_persona']);
+            if ($this->is_valid_persona($cookie_persona)) {
+                $persona = $cookie_persona;
+            }
+        }
+
+        // Try URL parameter
+        if (isset($_GET['persona'])) {
+            $url_persona = sanitize_key($_GET['persona']);
+            if ($this->is_valid_persona($url_persona)) {
+                $persona = $url_persona;
+
+                // Set cookie for future requests
+                if (!headers_sent()) {
+                    setcookie('_gtm_persona', $persona, time() + 30 * DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN);
+                }
+            }
+        }
+
+        // Allow custom detection via filter
+        $persona = apply_filters('personas_detected_persona', $persona);
+
+        // Set current persona
+        $this->current_persona = $persona;
+
+        // Maybe set up data layer for GTM
+        if (!is_admin()) {
+            add_action('wp_head', array($this, 'maybe_setup_gtm_datalayer'), 1);
+        }
+    }
+
+    /**
+     * Check if a persona is valid.
+     *
+     * @param string $persona Persona to check.
+     * @return bool
+     */
+    public function is_valid_persona($persona) {
+        return array_key_exists($persona, $this->personas);
+    }
+
+    /**
+     * Get current persona.
+     *
+     * @return string
+     */
+    public function get_current_persona() {
+        return $this->current_persona;
+    }
+
+    /**
+     * Set current persona.
+     *
+     * @param string $persona Persona to set.
+     * @return bool Success.
+     */
+    public function set_current_persona($persona) {
+        if ($this->is_valid_persona($persona)) {
+            $this->current_persona = $persona;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Maybe set up GTM data layer.
+     */
+    public function maybe_setup_gtm_datalayer() {
+        // Only if GTM integration is enabled
+        if (!get_option('personas_gtm_integration', true)) {
+            return;
+        }
+
+        // Output data layer
+        ?>
+        <script>
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+            'persona': '<?php echo esc_js($this->current_persona); ?>'
+        });
+        </script>
+        <?php
+    }
+}
+```
+
+#### Persona Content Class
+
+```php
+/**
+ * Class Personas_Content
+ *
+ * Handles storage and retrieval of persona-specific content.
+ */
+class Personas_Content {
+    /**
+     * Singleton instance.
+     *
+     * @var Personas_Content
+     */
+    private static $instance = null;
+
+    /**
+     * Get singleton instance.
+     *
+     * @return Personas_Content
+     */
+    public static function get_instance() {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    private function __construct() {
+        // Set up content filters
+        add_action('init', array($this, 'setup_content_filters'));
+    }
+
+    /**
+     * Set up content filters.
+     */
+    public function setup_content_filters() {
+        // Skip in admin
+        if (is_admin()) {
+            return;
+        }
+
+        // Main content filter
+        add_filter('the_content', array($this, 'filter_content'), 10, 1);
+
+        // Title filter
+        add_filter('the_title', array($this, 'filter_title'), 10, 2);
+
+        // Featured image filter
+        add_filter('post_thumbnail_id', array($this, 'filter_featured_image'), 10, 2);
+    }
+
+    /**
+     * Save persona variations for a post.
+     *
+     * @param int $post_id The post ID.
+     * @param string $persona The persona identifier.
+     * @param array $variations Content variations.
+     * @return bool Success.
+     */
+    public function save_variations($post_id, $persona, $variations) {
+        // Validate inputs
+        if (empty($post_id) || empty($persona)) {
+            return false;
+        }
+
+        // Ensure we have array of variations
+        if (!is_array($variations)) {
+            return false;
+        }
+
+        // Generate meta key
+        $meta_key = "_personas_{$persona}_variations";
+
+        // Save variations
+        return update_post_meta($post_id, $meta_key, $variations);
+    }
+
+    /**
+     * Get persona variations for a post.
+     *
+     * @param int $post_id The post ID.
+     * @param string $persona The persona identifier.
+     * @return array Content variations.
+     */
+    public function get_variations($post_id, $persona) {
+        // Generate meta key
+        $meta_key = "_personas_{$persona}_variations";
+
+        // Get variations
+        $variations = get_post_meta($post_id, $meta_key, true);
+
+        // Ensure we return an array
+        return is_array($variations) ? $variations : [];
+    }
+
+    /**
+     * Filter content for current persona.
+     *
+     * @param string $content The content.
+     * @return string Filtered content.
+     */
+    public function filter_content($content) {
+        // Get current post ID
+        $post_id = get_the_ID();
+        if (!$post_id) {
+            return $content;
+        }
+
+        // Get current persona
+        $persona_manager = Personas_Manager::get_instance();
+        $persona = $persona_manager->get_current_persona();
+
+        // Skip for default persona
+        if ($persona === 'default') {
+            return $content;
+        }
+
+        // Get variations
+        $variations = $this->get_variations($post_id, $persona);
+        if (empty($variations)) {
+            return $content;
+        }
+
+        // Parse blocks
+        $blocks = parse_blocks($content);
+
+        // Apply variations
+        $blocks = $this->apply_variations_to_blocks($blocks, $variations);
+
+        // Return modified content
+        return serialize_blocks($blocks);
+    }
+
+    /**
+     * Apply variations to parsed blocks.
+     *
+     * @param array $blocks Parsed blocks.
+     * @param array $variations Content variations.
+     * @return array Modified blocks.
+     */
+    private function apply_variations_to_blocks($blocks, $variations) {
+        foreach ($blocks as &$block) {
+            // Check if we have a block ID
+            if (!empty($block['attrs']['id']) && isset($variations[$block['attrs']['id']])) {
+                $block_id = $block['attrs']['id'];
+                $variation = $variations[$block_id];
+
+                // Apply variation based on block type
+                $this->apply_variation_to_block($block, $variation);
+            }
+
+            // Process inner blocks recursively
+            if (!empty($block['innerBlocks'])) {
+                $block['innerBlocks'] = $this->apply_variations_to_blocks(
+                    $block['innerBlocks'],
+                    $variations
+                );
+            }
+        }
+
+        return $blocks;
+    }
+
+    /**
+     * Apply variation to a specific block.
+     *
+     * @param array &$block Block to modify.
+     * @param mixed $variation Variation data.
+     */
+    private function apply_variation_to_block(&$block, $variation) {
+        switch ($block['blockName']) {
+            case 'core/paragraph':
+                // For paragraphs, update content
+                $block['attrs']['content'] = $variation;
+                if (isset($block['innerHTML'])) {
+                    $block['innerHTML'] = wpautop($variation);
+                }
+                break;
+
+            case 'core/heading':
+                // For headings, update content
+                $block['attrs']['content'] = $variation;
+                if (isset($block['innerHTML'])) {
+                    $level = $block['attrs']['level'] ?? 2;
+                    $block['innerHTML'] = "<h{$level}>{$variation}</h{$level}>";
+                }
+                break;
+
+            case 'core/image':
+                // For images, update attachment ID
+                if (is_numeric($variation)) {
+                    $block['attrs']['id'] = intval($variation);
+
+                    // Also update other image attributes
+                    $image = wp_get_attachment_image_src(intval($variation), 'full');
+                    if ($image) {
+                        $block['attrs']['url'] = $image[0];
+                    }
+                }
+                break;
+
+            default:
+                // For unknown blocks, try to update content attribute
+                if (is_string($variation) && isset($block['attrs']['content'])) {
+                    $block['attrs']['content'] = $variation;
+                }
+                elseif (is_array($variation)) {
+                    // For array variations, update multiple attributes
+                    foreach ($variation as $key => $value) {
+                        $block['attrs'][$key] = $value;
+                    }
+                }
+                break;
+        }
+    }
+
+    /**
+     * Filter title for current persona.
+     *
+     * @param string $title The title.
+     * @param int $post_id The post ID.
+     * @return string Filtered title.
+     */
+    public function filter_title($title, $post_id) {
+        // Skip empty post ID
+        if (!$post_id) {
+            return $title;
+        }
+
+        // Get current persona
+        $persona_manager = Personas_Manager::get_instance();
+        $persona = $persona_manager->get_current_persona();
+
+        // Skip for default persona
+        if ($persona === 'default') {
+            return $title;
+        }
+
+        // Get variations
+        $variations = $this->get_variations($post_id, $persona);
+
+        // Check for title variation
+        if (!empty($variations['title'])) {
+            return $variations['title'];
+        }
+
+        return $title;
+    }
+
+    /**
+     * Filter featured image for current persona.
+     *
+     * @param int $thumbnail_id The thumbnail ID.
+     * @param int|WP_Post $post The post object or ID.
+     * @return int Filtered thumbnail ID.
+     */
+    public function filter_featured_image($thumbnail_id, $post) {
+        // Get post ID
+        $post_id = is_object($post) ? $post->ID : (int)$post;
+
+        // Skip empty post ID
+        if (!$post_id) {
+            return $thumbnail_id;
+        }
+
+        // Get current persona
+        $persona_manager = Personas_Manager::get_instance();
+        $persona = $persona_manager->get_current_persona();
+
+        // Skip for default persona
+        if ($persona === 'default') {
+            return $thumbnail_id;
+        }
+
+        // Get variations
+        $variations = $this->get_variations($post_id, $persona);
+
+        // Check for featured image variation
+        if (!empty($variations['featured_image'])) {
+            return (int)$variations['featured_image'];
+        }
+
+        return $thumbnail_id;
+    }
+}
+```
+
+## Phase 2: Admin UI
+
+### Tasks
+
+1. **Create Admin Settings Page**
+
+    - Implement plugin configuration
+    - Add persona management
+    - Create GTM integration settings
+
+2. **Implement Gutenberg Integration**
+
+    - Create meta box for post editor
+    - Implement tabbed interface for personas
+    - Add block content editors
+
+3. **Add Media Management**
+    - Implement featured image selection
+    - Add media selection for blocks
+
+### Deliverables
+
+- Admin settings page
+- Post editor integration
+- JavaScript for Gutenberg integration
+
+### Admin UI Implementation
+
+#### Admin Class
+
+```php
+/**
+ * Class Personas_Admin
+ *
+ * Handles admin-related functionality.
+ */
+class Personas_Admin {
+    /**
+     * Initialize the class.
+     */
+    public function __construct() {
+        // Add admin menu
+        add_action('admin_menu', array($this, 'add_admin_menu'));
+
+        // Register settings
+        add_action('admin_init', array($this, 'register_settings'));
+
+        // Add meta boxes
+        add_action('add_meta_boxes', array($this, 'add_meta_boxes'));
+
+        // Save post meta
+        add_action('save_post', array($this, 'save_post_meta'));
+
+        // Enqueue admin assets
+        add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+    }
+
+    /**
+     * Add admin menu.
+     */
+    public function add_admin_menu() {
+        add_options_page(
+            __('Personas Settings', 'personas'),
+            __('Personas', 'personas'),
+            'manage_options',
+            'personas-settings',
+            array($this, 'render_settings_page')
+        );
+    }
+
+    /**
+     * Register settings.
+     */
+    public function register_settings() {
+        // Register settings group
+        register_setting('personas_settings', 'personas_settings');
+
+        // Add settings sections
+        add_settings_section(
+            'personas_general_section',
+            __('General Settings', 'personas'),
+            array($this, 'render_general_section'),
+            'personas_settings'
+        );
+
+        add_settings_section(
+            'personas_gtm_section',
+            __('Google Tag Manager Integration', 'personas'),
+            array($this, 'render_gtm_section'),
+            'personas_settings'
+        );
+
+        // Add settings fields
+        add_settings_field(
+            'personas_post_types',
+            __('Enabled Post Types', 'personas'),
+            array($this, 'render_post_types_field'),
+            'personas_settings',
+            'personas_general_section'
+        );
+
+        add_settings_field(
+            'personas_available_personas',
+            __('Available Personas', 'personas'),
+            array($this, 'render_personas_field'),
+            'personas_settings',
+            'personas_general_section'
+        );
+
+        add_settings_field(
+            'personas_gtm_integration',
+            __('GTM Integration', 'personas'),
+            array($this, 'render_gtm_integration_field'),
+            'personas_settings',
+            'personas_gtm_section'
+        );
+    }
+
+    /**
+     * Render settings page.
+     */
+    public function render_settings_page() {
+        // Check user capabilities
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        ?>
+        <div class="wrap">
+            <h1><?php echo esc_html(get_admin_page_title()); ?></h1>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields('personas_settings');
+                do_settings_sections('personas_settings');
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Render general section.
+     */
+    public function render_general_section() {
+        echo '<p>' . __('Configure general settings for the Personas plugin.', 'personas') . '</p>';
+    }
+
+    /**
+     * Render GTM section.
+     */
+    public function render_gtm_section() {
+        echo '<p>' . __('Configure Google Tag Manager integration.', 'personas') . '</p>';
+    }
+
+    /**
+     * Render post types field.
+     */
+    public function render_post_types_field() {
+        $options = get_option('personas_settings', array());
+        $enabled_post_types = isset($options['post_types']) ? $options['post_types'] : array('post', 'page');
+
+        // Get all public post types
+        $post_types = get_post_types(array('public' => true), 'objects');
+
+        foreach ($post_types as $post_type) {
+            $id = $post_type->name;
+            $checked = in_array($id, $enabled_post_types) ? 'checked' : '';
+
+            echo '<label>';
+            echo '<input type="checkbox" name="personas_settings[post_types][]" value="' . esc_attr($id) . '" ' . $checked . '>';
+            echo esc_html($post_type->label);
+            echo '</label><br>';
+        }
+
+        echo '<p class="description">' . __('Select which post types should have persona support.', 'personas') . '</p>';
+    }
+
+    /**
+     * Render personas field.
+     */
+    public function render_personas_field() {
+        $options = get_option('personas_settings', array());
+        $personas = isset($options['personas']) ? $options['personas'] : array(
+            'default' => __('Default', 'personas'),
+            'easy-breezy' => __('Easy-Breezy Cruiser', 'personas'),
+            'luxe' => __('Luxe Seafarer', 'personas'),
+            'thrill-seeker' => __('Thrill Seeker', 'personas')
+        );
+
+        // Hidden field for default persona
+        echo '<input type="hidden" name="personas_settings[personas][default]" value="' . esc_attr($personas['default']) . '">';
+
+        // Display table for other personas
+        echo '<table class="wp-list-table widefat fixed striped" id="personas-table">';
+        echo '<thead><tr>';
+        echo '<th>' . __('ID', 'personas') . '</th>';
+        echo '<th>' . __('Name', 'personas') . '</th>';
+        echo '<th>' . __('Actions', 'personas') . '</th>';
+        echo '</tr></thead>';
+        echo '<tbody>';
+
+        foreach ($personas as $id => $name) {
+            if ($id === 'default') continue; // Skip default
+
+            echo '<tr>';
+            echo '<td><input type="text" name="personas_settings[personas_ids][]" value="' . esc_attr($id) . '" readonly></td>';
+            echo '<td><input type="text" name="personas_settings[personas_names][]" value="' . esc_attr($name) . '"></td>';
+            echo '<td><button type="button" class="button remove-persona">' . __('Remove', 'personas') . '</button></td>';
+            echo '</tr>';
+        }
+
+        echo '</tbody>';
+        echo '<tfoot><tr>';
+        echo '<td colspan="3"><button type="button" class="button add-persona">' . __('Add Persona', 'personas') . '</button></td>';
+        echo '</tr></tfoot>';
+        echo '</table>';
+
+        // JavaScript for table interactions
+        ?>
+        <script>
+        jQuery(document).ready(function($) {
+            // Add persona
+            $('.add-persona').on('click', function() {
+                var row = $('<tr></tr>');
+                row.append('<td><input type="text" name="personas_settings[personas_ids][]" value=""></td>');
+                row.append('<td><input type="text" name="personas_settings[personas_names][]" value=""></td>');
+                row.append('<td><button type="button" class="button remove-persona">Remove</button></td>');
+
+                $('#personas-table tbody').append(row);
+            });
+
+            // Remove persona
+            $(document).on('click', '.remove-persona', function() {
+                $(this).closest('tr').remove();
+            });
+        });
+        </script>
+        <?php
+    }
+
+    /**
+     * Render GTM integration field.
+     */
+    public function render_gtm_integration_field() {
+        $options = get_option('personas_settings', array());
+        $gtm_integration = isset($options['gtm_integration']) ? $options['gtm_integration'] : true;
+
+        echo '<label>';
+        echo '<input type="checkbox" name="personas_settings[gtm_integration]" value="1" ' . checked(true, $gtm_integration, false) . '>';
+        echo __('Enable GTM integration', 'personas');
+        echo '</label>';
+
+        echo '<p class="description">' . __('When enabled, persona information will be pushed to the GTM data layer.', 'personas') . '</p>';
+    }
+
+    /**
+     * Add meta boxes.
+     */
+    public function add_meta_boxes() {
+        // Get enabled post types
+        $options = get_option('personas_settings', array());
+        $post_types = isset($options['post_types']) ? $options['post_types'] : array('post', 'page');
+
+        // Add meta box to enabled post types
+        foreach ($post_types as $post_type) {
+            add_meta_box(
+                'personas_content',
+                __('Persona Content', 'personas'),
+                array($this, 'render_meta_box'),
+                $post_type,
+                'normal',
+                'high'
+            );
+        }
+    }
+
+    /**
+     * Render meta box.
+     *
+     * @param WP_Post $post Current post.
+     */
+    public function render_meta_box($post) {
+        // Get persona manager
+        $persona_manager = Personas_Manager::get_instance();
+        $personas = $persona_manager->get_available_personas();
+
+        // Get persona content
+        $content_handler = Personas_Content::get_instance();
+
+        // Output nonce field
+        wp_nonce_field('personas_save_meta', 'personas_meta_nonce');
+
+        // Output tabs container
+        echo '<div class="personas-tabs">';
+
+        // Output tabs navigation
+        echo '<div class="personas-tabs-nav">';
+        foreach ($personas as $id => $name) {
+            if ($id === 'default') continue; // Skip default
+
+            $active = $id === 'easy-breezy' ? ' active' : '';
+            echo '<a href="#" data-tab="' . esc_attr($id) . '" class="personas-tab-nav' . $active . '">' . esc_html($name) . '</a>';
+        }
+        echo '</div>';
+
+        // Output tabs content
+        echo '<div class="personas-tabs-content">';
+
+        foreach ($personas as $id => $name) {
+            if ($id === 'default') continue; // Skip default
+
+            // Get variations for this persona
+            $variations = $content_handler->get_variations($post->ID, $id);
+
+            $active = $id === 'easy-breezy' ? ' active' : '';
+            echo '<div id="personas-tab-' . esc_attr($id) . '" class="personas-tab' . $active . '">';
+
+            // Title variation
+            echo '<div class="personas-field">';
+            echo '<label for="personas-' . esc_attr($id) . '-title">' . __('Title:', 'personas') . '</label>';
+            echo '<input type="text" id="personas-' . esc_attr($id) . '-title" name="personas[' . esc_attr($id) . '][title]" value="' . esc_attr($variations['title'] ?? '') . '" class="widefat">';
+            echo '</div>';
+
+            // Featured image variation
+            echo '<div class="personas-field">';
+            echo '<label>' . __('Featured Image:', 'personas') . '</label>';
+
+            $featured_id = $variations['featured_image'] ?? '';
+            $featured_url = $featured_id ? wp_get_attachment_image_url($featured_id, 'thumbnail') : '';
+
+            echo '<div class="personas-featured-image">';
+            if ($featured_url) {
+                echo '<img src="' . esc_url($featured_url) . '" alt="">';
+            }
+            echo '</div>';
+
+            echo '<input type="hidden" name="personas[' . esc_attr($id) . '][featured_image]" value="' . esc_attr($featured_id) . '" id="personas-' . esc_attr($id) . '-featured-image">';
+            echo '<button type="button" class="button personas-select-image" data-target="personas-' . esc_attr($id) . '-featured-image">' . __('Select Image', 'personas') . '</button>';
+
+            if ($featured_id) {
+                echo ' <button type="button" class="button personas-remove-image" data-target="personas-' . esc_attr($id) . '-featured-image">' . __('Remove', 'personas') . '</button>';
+            }
+
+            echo '</div>';
+
+            // Blocks container
+            echo '<div class="personas-blocks" data-persona="' . esc_attr($id) . '">';
+            echo '<h3>' . __('Content Blocks', 'personas') . '</h3>';
+            echo '<p class="description">' . __('Edit content for specific blocks. Leave empty to use default content.', 'personas') . '</p>';
+            echo '</div>';
+
+            echo '</div>'; // End tab
+        }
+
+        echo '</div>'; // End tabs content
+        echo '</div>'; // End tabs container
+    }
+
+    /**
+     * Save post meta.
+     *
+     * @param int $post_id The post ID.
+     */
+    public function save_post_meta($post_id) {
+        // Check if this is an autosave
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+            return;
+        }
+
+        // Check security nonce
+        if (!isset($_POST['personas_meta_nonce']) ||
+            !wp_verify_nonce($_POST['personas_meta_nonce'], 'personas_save_meta')) {
+            return;
+        }
+
+        // Check user permissions
+        if (!current_user_can('edit_post', $post_id)) {
+            return;
+        }
+
+        // Process personas data
+        if (isset($_POST['personas']) && is_array($_POST['personas'])) {
+            $content_handler = Personas_Content::get_instance();
+
+            foreach ($_POST['personas'] as $persona => $data) {
+                // Sanitize data
+                $variations = array();
+
+                // Title
+                if (!empty($data['title'])) {
+                    $variations['title'] = sanitize_text_
+```

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -6,40 +6,21 @@ This guide explains how to integrate persona-specific content into your theme an
 
 The plugin provides several shortcodes for displaying persona-specific content and adding persona switchers to your site.
 
-### Persona Content Shortcode
-
-Use the `[persona_content]` shortcode to display content specific to a persona:
-
-```text
-[persona_content persona="business" entity_id="123" field="content"]
-  Default content displayed for other personas
-[/persona_content]
-```
-
-**Parameters:**
-
-- `persona` - (Optional) The persona ID to display content for. If not specified, will use the current active persona.
-- `entity_id` - (Optional) The post/entity ID to get content from. Defaults to the current post.
-- `entity_type` - (Optional) The entity type. Defaults to 'post'.
-- `field` - (Optional) The field to display ('title', 'content', 'excerpt'). Defaults to 'content'.
-
-If persona-specific content is available, it will be displayed. Otherwise, the default content (if provided) will be shown.
-
 ### Conditional Persona Content Shortcode
 
 Use the `[if_persona]` shortcode to conditionally display content based on the active persona:
 
 ```text
-[if_persona is="business"]
-  Content only shown for business persona
+[if_persona is="easy-breezy"]
+  Content only shown for easy-breezy persona
 [/if_persona]
 
-[if_persona is="family,luxury"]
-  Content shown for family or luxury personas
+[if_persona is="luxe,thrill"]
+  Content shown for luxe or thrill personas
 [/if_persona]
 
-[if_persona not="business"]
-  Content shown for all personas except business
+[if_persona not="thrill"]
+  Content shown for all personas except thrill
 [/if_persona]
 ```
 
@@ -85,7 +66,7 @@ Returns the ID of the currently active persona.
 ### Set Persona
 
 ```php
-$success = cme_set_persona('business', true);
+$success = cme_set_persona('easy-breezy', true);
 ```
 
 Sets the active persona.
@@ -93,20 +74,6 @@ Sets the active persona.
 - First parameter: The persona ID to set
 - Second parameter: Whether to set a cookie (defaults to true)
 - Returns: Boolean indicating success
-
-### Get Persona Content
-
-```php
-$content = cme_get_persona_content($post_id, 'post', 'content', $persona_id);
-```
-
-Gets persona-specific content for an entity.
-
-- First parameter: The entity ID (e.g., post ID)
-- Second parameter: The entity type (default: 'post')
-- Third parameter: The content field name (default: 'content')
-- Fourth parameter: The persona ID (null for current)
-- Returns: The persona-specific content, or original content if not found
 
 ### Get All Personas
 
@@ -127,47 +94,34 @@ Returns an array of all available personas in the format `[id => name]`.
 </div>
 ```
 
-### Displaying Persona-Specific Content in a Template
-
-```php
-// In your theme's template file
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
- <header class="entry-header">
-  <h1 class="entry-title">
-   <?php echo cme_get_persona_content(get_the_ID(), 'post', 'title'); ?>
-  </h1>
- </header>
-
- <div class="entry-content">
-  <?php echo cme_get_persona_content(get_the_ID(), 'post', 'content'); ?>
- </div>
-</article>
-```
-
 ### Using Conditional Persona Content in a Template
 
 ```php
 <?php
-// Check if the current persona is 'business'
-if (cme_get_current_persona() === 'business') :
+// Check if the current persona is 'luxe'
+if (cme_get_current_persona() === 'luxe') :
 ?>
-  <div class="business-specific-notice">
-    Special offer for business travelers!
+  <div class="luxe-specific-notice">
+    Special offer for luxury travelers!
   </div>
 <?php endif; ?>
 ```
 
-### Dynamic Content Refresh
+### Using Shortcodes in Templates
 
-To enable dynamic content refreshing without page reload when a persona is switched:
-
-1. Add the `cme-persona-dynamic` class to elements with persona-specific content
-2. Add data attributes for the post ID and field
-
-```html
-<div class="cme-persona-dynamic" data-post-id="123" data-field="content">
- <!-- Content will be dynamically updated when persona changes -->
- <?php echo cme_get_persona_content(123, 'post', 'content'); ?>
+```php
+<div class="trip-highlights">
+  <h2>Highlights of Your Trip</h2>
+  
+  <?php echo do_shortcode('[if_persona is="easy-breezy"]
+    <p>Relaxing beaches and no-hassle excursions await!</p>
+    <img src="/images/easy-cruise.jpg" alt="Relaxing cruise experience">
+  [/if_persona]'); ?>
+  
+  <?php echo do_shortcode('[if_persona is="thrill"]
+    <p>Get ready for adventure with our extreme excursions!</p>
+    <img src="/images/thrill-cruise.jpg" alt="Adventure cruise experience">
+  [/if_persona]'); ?>
 </div>
 ```
 
@@ -195,13 +149,31 @@ For the persona switcher:
 }
 ```
 
-For persona-specific content:
+## Best Practices
 
-```css
-.cme-personalized-content {
- /* Styles for persona-specific content */
-}
-.cme-personalized-content-tag {
- /* Styles for the persona tag */
-}
+1. **Use boundary-based shortcodes**: The `[if_persona]` shortcode is the primary method for persona content customization. It provides clear boundaries around content and maintains compatibility with other WordPress functionality.
+
+2. **Nest shortcodes for complex scenarios**: You can nest `[if_persona]` shortcodes for more complex conditional logic:
+
+```text
+[if_persona not="thrill"]
+  <div class="relaxation-options">
+    <h2>Relaxation Options</h2>
+    
+    [if_persona is="luxe"]
+      <div class="premium-options">
+        <h3>Premium Relaxation</h3>
+        <!-- Premium content here -->
+      </div>
+    [/if_persona]
+    
+    <div class="standard-options">
+      <!-- Standard content here -->
+    </div>
+  </div>
+[/if_persona]
 ```
+
+3. **Default content first**: Always design your pages with default content first, then add persona-specific variations. This ensures a good experience for all users, even those who don't have a persona assigned.
+
+4. **Add persona switchers in accessible locations**: Provide users with easy ways to change their persona in common areas like header, footer, or sidebar.

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -10,7 +10,7 @@ The plugin provides several shortcodes for displaying persona-specific content a
 
 Use the `[if_persona]` shortcode to conditionally display content based on the active persona:
 
-```text
+```php
 [if_persona is="easy-breezy"]
   Content only shown for easy-breezy persona
 [/if_persona]
@@ -35,13 +35,13 @@ You can use either parameter, but not both at the same time.
 
 Use the `[persona_switcher]` shortcode to add a persona switcher to your site:
 
-```text
+```php
 [persona_switcher]
 ```
 
 Or with custom options:
 
-```text
+```php
 [persona_switcher display="dropdown" button_text="Choose Your Experience" class="my-custom-class"]
 ```
 
@@ -155,7 +155,7 @@ For the persona switcher:
 
 2. **Nest shortcodes for complex scenarios**: You can nest `[if_persona]` shortcodes for more complex conditional logic:
 
-```text
+```html
 [if_persona not="thrill"]
   <div class="relaxation-options">
     <h2>Relaxation Options</h2>

--- a/docs/guides/PERSONAS.md
+++ b/docs/guides/PERSONAS.md
@@ -23,7 +23,7 @@ The persona system uses shortcodes to define boundaries around content that shou
 
 The primary shortcode used for persona-specific content is `[if_persona]`:
 
-```
+```php
 [if_persona is="easy-breezy"]
 This content will only be shown to visitors with the "Easy-Breezy Cruiser" persona.
 [/if_persona]
@@ -33,7 +33,7 @@ This content will only be shown to visitors with the "Easy-Breezy Cruiser" perso
 
 You can target multiple personas by separating them with commas:
 
-```
+```php
 [if_persona is="easy-breezy,luxe"]
 This content will be shown to both "Easy-Breezy Cruiser" and "Luxe Seafarer" personas.
 [/if_persona]
@@ -43,7 +43,7 @@ This content will be shown to both "Easy-Breezy Cruiser" and "Luxe Seafarer" per
 
 You can also display content for everyone EXCEPT specific personas:
 
-```
+```php
 [if_persona not="thrill"]
 This content will be shown to everyone EXCEPT "Thrill Seeker" personas.
 [/if_persona]
@@ -74,7 +74,7 @@ Example with custom HTML:
 
 You can nest persona shortcodes for more complex conditional logic:
 
-```
+```html
 [if_persona not="thrill"]
   <p>Relaxation is our priority...</p>
   
@@ -90,7 +90,7 @@ You can nest persona shortcodes for more complex conditional logic:
 
 You can preview how content will appear to different personas by adding a `persona` query parameter to any URL:
 
-```
+```php
 https://your-site.com/page/?persona=easy-breezy
 ```
 
@@ -104,7 +104,7 @@ When editing content in the WordPress admin, you can use the persona selector in
 
 You can add a persona switcher to your site that allows visitors to manually select their persona:
 
-```
+```php
 [persona_switcher]
 ```
 
@@ -114,11 +114,12 @@ This will display a set of buttons, one for each persona. Visitors can click to 
 
 You can customize the appearance of the switcher:
 
-```
+```php
 [persona_switcher display="dropdown" button_text="Choose Your Cruise Style"]
 ```
 
 Options:
+
 - `display`: "buttons" (default) or "dropdown"
 - `button_text`: The label for the dropdown select
 - `class`: Additional CSS classes for styling
@@ -137,6 +138,7 @@ Behind the scenes, the persona system:
 ### Performance Considerations
 
 The shortcode-based approach is lightweight and efficient:
+
 - No duplicate content storage
 - Minimal database queries
 - Compatible with caching plugins

--- a/docs/guides/PERSONAS.md
+++ b/docs/guides/PERSONAS.md
@@ -54,17 +54,19 @@ This content will be shown to everyone EXCEPT "Thrill Seeker" personas.
 A major advantage of the boundary-based shortcode approach is that you can include any content within the shortcode boundaries, including:
 
 - Images and media
-- Third-party shortcodes (like Meta Slider)
+- Third-party shortcodes
 - Complex HTML elements
 - Other WordPress blocks and embeds
 
-Example with Meta Slider:
+Example with custom HTML:
 
-```
+```html
 [if_persona is="luxe"]
 <h2>Luxury Accommodations</h2>
 <p>Indulge in our premium suite options...</p>
-[metaslider id="123"]
+<div class="featured-image">
+  <img src="/images/luxury-suite.jpg" alt="Luxury Suite">
+</div>
 [/if_persona]
 ```
 

--- a/includes/class-ajax-handler.php
+++ b/includes/class-ajax-handler.php
@@ -78,9 +78,9 @@ class Ajax_Handler {
 		}
 
 		// Get parameters.
-		$post_id  = isset( $_POST['post_id'] ) ? intval( $_POST['post_id'] ) : 0;
-		$field    = isset( $_POST['field'] ) ? sanitize_key( $_POST['field'] ) : 'content';
-		$persona  = isset( $_POST['persona'] ) ? sanitize_key( $_POST['persona'] ) : '';
+		$post_id = isset( $_POST['post_id'] ) ? intval( $_POST['post_id'] ) : 0;
+		$field   = isset( $_POST['field'] ) ? sanitize_key( $_POST['field'] ) : 'content';
+		$persona = isset( $_POST['persona'] ) ? sanitize_key( $_POST['persona'] ) : '';
 
 		if ( empty( $post_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'cme-personas' ) ) );
@@ -88,7 +88,7 @@ class Ajax_Handler {
 
 		// Get content manager.
 		$content_manager = Persona_Content::get_instance();
-		$api = Personas_API::get_instance();
+		$api             = Personas_API::get_instance();
 
 		// Get the content.
 		$content = $api->get_content( $post_id, 'post', $field, $persona );
@@ -96,9 +96,9 @@ class Ajax_Handler {
 		// Return result.
 		wp_send_json_success(
 			array(
-				'content'  => $content,
-				'field'    => $field,
-				'persona'  => $persona,
+				'content' => $content,
+				'field'   => $field,
+				'persona' => $persona,
 			)
 		);
 	}
@@ -185,7 +185,7 @@ class Ajax_Handler {
 		$persona_excerpt = $content_manager->get_content( $post_id, 'post', 'excerpt', $persona );
 
 		// Build preview HTML.
-		$preview_html = '<div class="cme-persona-preview">';
+		$preview_html  = '<div class="cme-persona-preview">';
 		$preview_html .= '<h2>' . esc_html( $persona_title ) . '</h2>';
 
 		if ( ! empty( $persona_excerpt ) ) {

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -102,9 +102,6 @@ class Frontend {
 
 		// Add frontend assets.
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
-
-		// Add filter for content to handle metaslider compatibility.
-		add_filter( 'the_content', array( $this, 'filter_content_for_metaslider' ), 999 );
 	}
 
 	/**
@@ -144,78 +141,6 @@ class Frontend {
 				)
 			);
 		}
-	}
-
-	/**
-	 * Filter content to handle Meta Slider compatibility.
-	 *
-	 * This function detects if the content contains Meta Slider shortcodes
-	 * and processes them properly to avoid conflicts.
-	 *
-	 * @since     1.4.2
-	 * @param     string $content   The content to filter.
-	 * @return    string            The filtered content.
-	 */
-	public function filter_content_for_metaslider( $content ) {
-		// Check if content contains a Meta Slider shortcode.
-		if ( ! empty( $content ) && strpos( $content, '[metaslider' ) !== false ) {
-			// Process meta slider shortcodes separately to avoid interference.
-			$content = $this->process_metaslider_shortcodes( $content );
-		}
-
-		return $content;
-	}
-
-	/**
-	 * Process content with Meta Slider shortcodes safely.
-	 *
-	 * This method handles shortcode processing in a way that doesn't interfere
-	 * with Meta Slider shortcodes by temporarily removing our shortcodes.
-	 *
-	 * @since     1.4.2
-	 * @param     string $content   Content to process.
-	 * @return    string            Processed content.
-	 */
-	private function process_metaslider_shortcodes( $content ) {
-		// Remember our shortcode handlers.
-		$persona_content_handler  = $this->get_shortcode_handler( 'persona_content' );
-		$persona_switcher_handler = $this->get_shortcode_handler( 'persona_switcher' );
-		$if_persona_handler       = $this->get_shortcode_handler( 'if_persona' );
-
-		// Temporarily remove our shortcodes.
-		remove_shortcode( 'persona_content' );
-		remove_shortcode( 'persona_switcher' );
-		remove_shortcode( 'if_persona' );
-
-		// Process Meta Slider shortcodes.
-		$content = do_shortcode( $content );
-
-		// Re-add our shortcodes.
-		if ( $persona_content_handler ) {
-			add_shortcode( 'persona_content', $persona_content_handler );
-		}
-
-		if ( $persona_switcher_handler ) {
-			add_shortcode( 'persona_switcher', $persona_switcher_handler );
-		}
-
-		if ( $if_persona_handler ) {
-			add_shortcode( 'if_persona', $if_persona_handler );
-		}
-
-		return $content;
-	}
-
-	/**
-	 * Get the current handler for a shortcode.
-	 *
-	 * @since     1.4.2
-	 * @param     string $tag   The shortcode tag.
-	 * @return    callable|false The shortcode handler or false if not found.
-	 */
-	private function get_shortcode_handler( $tag ) {
-		global $shortcode_tags;
-		return isset( $shortcode_tags[ $tag ] ) ? $shortcode_tags[ $tag ] : false;
 	}
 
 	/**

--- a/includes/class-persona-content.php
+++ b/includes/class-persona-content.php
@@ -4,6 +4,9 @@
  *
  * Handles persona-specific content storage and retrieval.
  *
+ * @deprecated 1.6.0 This class uses the entity-based content approach which is being replaced
+ *                   by the boundary-based shortcode approach. Use [if_persona] shortcodes instead.
+ *
  * @since      1.1.0
  * @package    CME_Personas
  */
@@ -15,6 +18,9 @@ namespace CME_Personas;
  *
  * This class is responsible for storing and retrieving persona-specific content.
  * It provides methods for getting and setting content variations for different personas.
+ *
+ * @deprecated 1.6.0 This class is being phased out in favor of the boundary-based shortcode approach.
+ *                   Code should migrate to using [if_persona] shortcodes for conditional content.
  *
  * @since      1.1.0
  * @package    CME_Personas

--- a/includes/class-persona-integrator.php
+++ b/includes/class-persona-integrator.php
@@ -189,6 +189,9 @@ class Persona_Integrator {
 			/**
 			 * Get persona-specific content for an entity.
 			 *
+			 * @deprecated 1.6.0 This function uses the entity-based content approach which is being replaced
+			 *                   by the boundary-based shortcode approach. Use [if_persona] shortcodes instead.
+			 *
 			 * @since     1.1.0
 			 * @param     int    $entity_id       The entity ID (e.g., post ID).
 			 * @param     string $entity_type     The entity type (default: 'post').
@@ -386,6 +389,9 @@ class Persona_Integrator {
 	/**
 	 * Register meta boxes.
 	 *
+	 * @deprecated 1.6.0 The entity-based content approach is being phased out in favor of the
+	 *                   boundary-based shortcode approach. Use [if_persona] shortcodes instead.
+	 *
 	 * @since    1.1.0
 	 */
 	public function register_meta_boxes() {
@@ -420,6 +426,12 @@ class Persona_Integrator {
 
 		// Remove the default persona since we don't store content for it.
 		unset( $personas['default'] );
+
+		// Show deprecation notice
+		echo '<div class="notice notice-warning inline"><p>';
+		echo '<strong>' . esc_html__( 'Deprecated Feature:', 'cme-personas' ) . '</strong> ';
+		echo esc_html__( 'This entity-based content approach is being phased out in favor of the boundary-based [if_persona] shortcode approach. We recommend using shortcodes for new content.', 'cme-personas' );
+		echo '</p></div>';
 
 		// Check if we have any personas.
 		if ( empty( $personas ) ) {

--- a/includes/class-persona-integrator.php
+++ b/includes/class-persona-integrator.php
@@ -427,7 +427,7 @@ class Persona_Integrator {
 		// Remove the default persona since we don't store content for it.
 		unset( $personas['default'] );
 
-		// Show deprecation notice
+		// Show deprecation notice.
 		echo '<div class="notice notice-warning inline"><p>';
 		echo '<strong>' . esc_html__( 'Deprecated Feature:', 'cme-personas' ) . '</strong> ';
 		echo esc_html__( 'This entity-based content approach is being phased out in favor of the boundary-based [if_persona] shortcode approach. We recommend using shortcodes for new content.', 'cme-personas' );

--- a/includes/class-personas-api.php
+++ b/includes/class-personas-api.php
@@ -177,6 +177,9 @@ class Personas_API {
 	/**
 	 * Get persona-specific content for an entity.
 	 *
+	 * @deprecated 1.6.0 This method uses the entity-based content approach which is being replaced
+	 *                   by the boundary-based shortcode approach. Use [if_persona] shortcodes instead.
+	 *
 	 * @since     1.1.0
 	 * @param     int    $entity_id       The entity ID (e.g., post ID).
 	 * @param     string $entity_type     The entity type (default: 'post').
@@ -190,6 +193,9 @@ class Personas_API {
 
 	/**
 	 * Set persona-specific content for an entity.
+	 *
+	 * @deprecated 1.6.0 This method uses the entity-based content approach which is being replaced
+	 *                   by the boundary-based shortcode approach. Use [if_persona] shortcodes instead.
 	 *
 	 * @since     1.1.0
 	 * @param     int    $entity_id       The entity ID (e.g., post ID).
@@ -206,6 +212,9 @@ class Personas_API {
 	/**
 	 * Process block content for persona-specific variations.
 	 *
+	 * @deprecated 1.6.0 This method uses the entity-based content approach which is being replaced
+	 *                   by the boundary-based shortcode approach. Use [if_persona] shortcodes instead.
+	 *
 	 * @since     1.1.0
 	 * @param     string $content         The content with blocks.
 	 * @param     string $persona_id      The persona ID.
@@ -217,6 +226,9 @@ class Personas_API {
 
 	/**
 	 * Get all personas that have content for a specific entity.
+	 *
+	 * @deprecated 1.6.0 This method uses the entity-based content approach which is being replaced
+	 *                   by the boundary-based shortcode approach. Use [if_persona] shortcodes instead.
 	 *
 	 * @since     1.1.0
 	 * @param     int    $entity_id       The entity ID.

--- a/includes/class-personas-api.php
+++ b/includes/class-personas-api.php
@@ -71,8 +71,8 @@ class Personas_API {
 		$this->persona_manager = Persona_Manager::get_instance();
 		$this->persona_content = Persona_Content::get_instance();
 
-		// Shortcodes are now handled by Frontend class to avoid duplication
-		// Removed: add_action( 'init', array( $this, 'register_shortcodes' ) );
+		// Shortcodes are now handled by Frontend class to avoid duplication.
+		// Removed: add_action( 'init', array( $this, 'register_shortcodes' ) ).
 	}
 
 	/**
@@ -83,8 +83,8 @@ class Personas_API {
 	 * @deprecated 1.4.2 Shortcodes are now handled by Frontend class
 	 */
 	public function register_shortcodes() {
-		// This method is kept for backward compatibility but does nothing
-		// Removed: add_shortcode calls
+		// This method is kept for backward compatibility but does nothing.
+		// Removed: add_shortcode calls.
 	}
 
 	/**
@@ -99,7 +99,7 @@ class Personas_API {
 	 * @deprecated 1.4.2 Use the Frontend class implementation instead
 	 */
 	public function persona_content_shortcode( $atts, $content = null ) {
-		// Forward to the Frontend class implementation
+		// Forward to the Frontend class implementation.
 		$frontend = Frontend::get_instance();
 		return $frontend->persona_content_shortcode( $atts, $content );
 	}
@@ -115,7 +115,7 @@ class Personas_API {
 	 * @deprecated 1.4.2 Use the Frontend class implementation instead
 	 */
 	public function persona_switcher_shortcode( $atts ) {
-		// Forward to the Frontend class implementation
+		// Forward to the Frontend class implementation.
 		$frontend = Frontend::get_instance();
 		return $frontend->persona_switcher_shortcode( $atts );
 	}

--- a/public/css/personas-frontend.css
+++ b/public/css/personas-frontend.css
@@ -51,56 +51,6 @@
 	border-color: #006ba1;
 }
 
-/* Meta Slider Compatibility Styles */
-.metaslider {
-	/* Ensure Meta Slider has proper z-index to avoid persona element issues */
-	position: relative;
-	z-index: 1;
-}
-
-.metaslider .slides img {
-	/* Ensure images maintain their aspect ratio */
-	height: auto !important;
-}
-
-/* Fix for Meta Slider captions in persona content */
-.metaslider .caption-wrap {
-	position: absolute !important;
-	bottom: 0 !important;
-	left: 0 !important;
-	background: rgb(0 0 0 / 70%) !important;
-	color: white !important;
-	margin: 0 !important;
-	display: block !important;
-	width: 100% !important;
-	line-height: 1.4em !important;
-}
-
-/* Fix for navigation controls in persona content */
-.metaslider .flex-control-nav {
-	bottom: 10px !important;
-	z-index: 10 !important;
-}
-
-.metaslider .flex-direction-nav a {
-	z-index: 10 !important;
-}
-
-/* Ensure proper display within persona shortcodes */
-[if_persona] .metaslider,
-[persona_content] .metaslider {
-	overflow: visible !important;
-}
-
-/* Override any potential conflicts with flex-based sliders */
-.metaslider .flexslider {
-	margin-bottom: 0 !important;
-}
-
-.metaslider .flexslider .slides > li {
-	position: relative !important;
-}
-
 /* Ensure proper rendering in responsive contexts */
 @media (width <= 768px) {
 	.cme-persona-buttons {
@@ -111,54 +61,4 @@
 		width: 100%;
 		margin-bottom: 0.5em;
 	}
-
-	/* Meta Slider responsive fixes */
-	.metaslider .caption-wrap {
-		position: relative !important;
-		background: #000 !important;
-		padding: 10px !important;
-	}
-}
-
-/* Meta Slider compatibility fix */
-
-/* Base Meta Slider styles - less specific selectors first */
-.metaslider {
-  text-align: center;
-  margin: 0 auto !important;
-  width: auto !important;
-  max-width: 100% !important;
-  display: block !important;
-}
-
-/* More specific selectors for contextual styling */
-.entry-content .metaslider,
-.post-content .metaslider,
-.page-content .metaslider,
-.widget .metaslider {
-  margin: 0 auto 1.5em !important;
-  display: block !important;
-}
-
-/* FlexSlider specific styles */
-.metaslider .flexslider {
-  margin: 0 auto !important;
-  text-align: center !important;
-}
-
-/* Ensure images display properly */
-.metaslider img {
-  height: auto;
-  max-width: 100%;
-}
-
-/* Preserve MetaSlider's box model */
-.metaslider * {
-  box-sizing: content-box;
-}
-
-/* Navigation alignment */
-.metaslider .flex-control-nav {
-  width: 100% !important;
-  text-align: center !important;
 }


### PR DESCRIPTION
This PR:

1. Removes all MetaSlider-specific code from documentation and implementation
2. Deprecates the entity-based content system in favor of boundary-based shortcodes
3. Updates documentation to focus on the [if_persona] shortcode approach
4. Fixes various linting issues in PHP and Markdown files
5. Ensures code follows WordPress coding standards