### PR TITLE
Fix: Comment out reference to missing class-persona-content.php file

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -82,7 +82,7 @@ class Plugin {
 		require_once CME_PLUGIN_DIR . 'includes/class-shortcodes.php';
 		require_once CME_PLUGIN_DIR . 'includes/class-settings.php';
 		require_once CME_PLUGIN_DIR . 'includes/class-persona-manager.php';
-		require_once CME_PLUGIN_DIR . 'includes/class-persona-content.php';
+		// require_once CME_PLUGIN_DIR . 'includes/class-persona-content.php'; // File not found - refactored out?
 		require_once CME_PLUGIN_DIR . 'includes/class-personas-api.php';
 
 		// Load frontend class to ensure shortcodes are registered.


### PR DESCRIPTION
This PR fixes a fatal error that occurs when WordPress tries to load a non-existent file.

## Issue
When activating or running the plugin, WordPress produces a fatal error:


## Fix
- Comment out the include statement for the missing file in class-plugin.php
- Add a comment noting that the file may have been refactored out in a previous update

## Testing
After this change, the plugin should load correctly without the fatal error.

The content from the missing class likely has been incorporated into other components, as no other parts of the codebase reference this class.