### PR TITLE
feat: redesign personas dashboard

### DIFF
--- a/admin/css/personas-dashboard.css
+++ b/admin/css/personas-dashboard.css
@@ -1,177 +1,191 @@
 /**
- * Dashboard Styles for Persona administration
- *
- * @package    CME_Personas
- * @version    1.4.0
+ * Personas Dashboard Styles.
  */
 
-/* Dashboard Main Area */
 .cme-personas-dashboard {
-  margin: 20px 0;
-  background: #fff;
+    max-width: 1200px;
 }
 
-.cme-personas-dashboard .welcome-panel {
-  padding-bottom: 23px;
+/* Persona Cards Section */
+.cme-dashboard-section {
+    margin-bottom: 30px;
 }
 
-.cme-personas-dashboard .welcome-panel h2 {
-  margin: 0;
-  font-size: 21px;
-  font-weight: 400;
-  line-height: 1.2;
+.cme-dashboard-section h2 {
+    border-bottom: 1px solid #ddd;
+    margin-bottom: 15px;
+    padding-bottom: 10px;
 }
 
-.cme-personas-dashboard .welcome-panel-content {
-  margin-left: 13px;
-  max-width: 1500px;
+/* Persona Cards Grid */
+.cme-persona-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
 }
 
-.cme-personas-dashboard .about-description {
-  margin: 1em 0;
-  font-size: 16px;
-  line-height: 1.4;
+.cme-persona-card {
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+    padding: 20px;
+    transition: all 0.2s ease;
 }
 
-/* Stats Boxes */
-.cme-persona-count {
-  padding-left: 26px;
-  background: transparent url('../images/icon-persona-16.png') no-repeat left center;
+.cme-persona-card:hover {
+    border-color: #2271b1;
+    box-shadow: 0 4px 8px rgb(0 0 0 / 10%);
+    transform: translateY(-2px);
 }
 
-.cme-personas-dashboard .count {
-  display: inline-block;
-  min-width: 18px;
-  padding: 0 2px;
-  height: 18px;
-  border-radius: 9px;
-  background-color: #72aee6;
-  color: #fff;
-  font-size: 11px;
-  line-height: 1.6;
-  text-align: center;
-  margin-right: 5px;
+.cme-persona-card-title {
+    border-bottom: 1px solid #eee;
+    color: #1d2327;
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-bottom: 15px;
+    padding-bottom: 10px;
 }
 
-/* Quick Actions Box */
-.cme-personas-quick-actions {
-  margin-top: 20px;
+/* Persona Images Section */
+.cme-persona-images {
+    display: flex;
+    gap: 10px;
+    justify-content: space-between;
+    margin-bottom: 15px;
 }
 
-.cme-personas-quick-actions h3 {
-  margin-top: 0;
-  padding: 8px 12px;
-  border-bottom: 1px solid #eee;
-  font-size: 14px;
+.cme-persona-image {
+    flex: 1;
+    text-align: center;
 }
 
-.cme-personas-quick-actions ul {
-  padding: 0 12px;
+.cme-persona-image img {
+    border-radius: 50%;
+    height: 80px;
+    object-fit: cover;
+    width: 80px;
 }
 
-.cme-personas-quick-actions .button-secondary {
-  margin-right: 5px;
+.cme-persona-image-name {
+    color: #50575e;
+    font-size: 0.9em;
+    margin-top: 5px;
 }
 
-/* Recent Posts */
-.cme-personas-dashboard .inside ul {
-  margin: 0;
+.cme-persona-image-placeholder {
+    align-items: center;
+    background-color: #f0f0f1;
+    border-radius: 50%;
+    color: #2271b1;
+    display: flex;
+    font-size: 40px;
+    height: 80px;
+    justify-content: center;
+    margin: 0 auto;
+    width: 80px;
 }
 
-.cme-personas-dashboard .inside ul li {
-  margin-bottom: 8px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid #eee;
+/* Persona Attributes Section */
+.cme-persona-attributes {
+    margin-bottom: 15px;
 }
 
-.cme-personas-dashboard .inside ul li:last-child {
-  margin-bottom: 0;
-  padding-bottom: 0;
-  border-bottom: none;
+.cme-persona-attributes ul {
+    margin: 0;
+    padding-left: 20px;
 }
 
-.cme-personas-dashboard .post-date {
-  display: inline-block;
-  margin-left: 8px;
-  color: #777;
+.cme-persona-attributes li {
+    margin-bottom: 5px;
 }
 
-/* Columns Layout */
-.cme-personas-dashboard .metabox-holder {
-  clear: both;
-  margin-top: 20px;
+/* Persona Actions */
+.cme-persona-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 15px;
 }
 
-.postbox .hndle {
-  cursor: default !important;
+.cme-persona-actions a {
+    background-color: #f6f7f7;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    color: #50575e;
+    display: inline-block;
+    font-size: 0.9em;
+    padding: 5px 10px;
+    text-decoration: none;
+    transition: all 0.2s ease;
 }
 
-/* Statistics Section */
-.persona-stats {
-  display: flex;
-  flex-wrap: wrap;
-  margin-top: 15px;
+.cme-persona-actions a:hover {
+    background-color: #f0f0f1;
+    border-color: #2271b1;
+    color: #2271b1;
 }
 
-.persona-stat-box {
-  width: 46%;
-  margin-right: 2%;
-  margin-bottom: 15px;
-  padding: 15px;
-  background: #fff;
-  border: 1px solid #ccd0d4;
-  box-shadow: 0 1px 1px rgb(0 0 0 / 4%);
+/* Documentation Cards */
+.cme-card-grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
 }
 
-.persona-stat-box h3 {
-  margin-top: 0;
-  border-bottom: 1px solid #eee;
-  padding-bottom: 10px;
+.cme-card {
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+    color: #1d2327;
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+    text-decoration: none;
+    transition: all 0.2s ease;
 }
 
-.persona-stat-value {
-  font-size: 24px;
-  font-weight: 600;
-  margin: 10px 0;
+.cme-card:hover {
+    border-color: #2271b1;
+    box-shadow: 0 4px 8px rgb(0 0 0 / 10%);
+    transform: translateY(-2px);
 }
 
-/* Dashboard Widget Section */
-.persona-dashboard-widget {
-  margin-bottom: 20px;
+.cme-card-icon {
+    color: #2271b1;
+    font-size: 2em;
+    margin-bottom: 15px;
 }
 
-.persona-dashboard-widget-header {
-  padding: 8px 12px;
-  border-bottom: 1px solid #eee;
-  background: #f5f5f5;
+.cme-card-title {
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-bottom: 10px;
 }
 
-.persona-dashboard-widget-content {
-  padding: 12px;
+.cme-card-desc {
+    color: #50575e;
+    font-size: 0.9em;
 }
 
-/* Documentation Section */
-.cme-personas-docs {
-  margin-top: 20px;
-  padding: 15px;
-  background: #fff;
-  border-left: 4px solid #007cba;
-}
-
-.cme-personas-docs h3 {
-  margin-top: 0;
-}
-
-/* Wrapper fix to ensure white background */
-.wrap.cme-personas-dashboard {
-  background-color: #fff;
-}
-
-/* Media Queries */
+/* Responsive Design */
 @media screen and (width <= 782px) {
-  .persona-stat-box
-  .postbox-container {
-    width: 100% !important;
-    margin-right: 0 !important;
-  }
+    .cme-persona-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .cme-card-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .cme-persona-images {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .cme-persona-image {
+        margin-bottom: 15px;
+    }
 }

--- a/includes/class-personas-dashboard.php
+++ b/includes/class-personas-dashboard.php
@@ -61,7 +61,7 @@ class Personas_Dashboard {
 		if ( 'toplevel_page_cme-personas-dashboard' === $hook ) {
 			wp_enqueue_style(
 				'cme-personas-dashboard',
-				CME_PERSONAS_URL . 'admin/css/dashboard.css',
+				CME_PERSONAS_URL . 'admin/css/personas-dashboard.css',
 				array(),
 				CME_PERSONAS_VERSION,
 				'all'
@@ -97,104 +97,165 @@ class Personas_Dashboard {
 	}
 
 	/**
+	 * Get image filename without extension.
+	 *
+	 * @param int $attachment_id The attachment ID.
+	 * @return string The filename without extension.
+	 */
+	private function get_image_name( $attachment_id ) {
+		if ( empty( $attachment_id ) ) {
+			return __( 'Unknown', 'cme-personas' );
+		}
+
+		$filename      = basename( get_attached_file( $attachment_id ) );
+		$name_parts    = explode( '.', $filename );
+		$name_no_ext   = $name_parts[0];
+		$name_readable = ucfirst( str_replace( array( '-', '_' ), ' ', $name_no_ext ) );
+
+		// If it's a full path with multiple dots, get only the filename.
+		if ( count( $name_parts ) > 2 ) {
+			$extension     = array_pop( $name_parts );
+			$name_no_ext   = implode( '.', $name_parts );
+			$name_readable = ucfirst( str_replace( array( '-', '_' ), ' ', $name_no_ext ) );
+		}
+
+		// Use just the first word if the name is multiple words.
+		$words = explode( ' ', $name_readable );
+		if ( count( $words ) > 0 ) {
+			return $words[0];
+		}
+
+		return $name_readable;
+	}
+
+	/**
 	 * Render the dashboard page.
 	 *
 	 * @since    1.3.0
 	 */
 	public function render_dashboard_page() {
-		// Get counts.
-		$persona_count = wp_count_posts( 'persona' )->publish;
-
-		// Get recent personas.
-		$recent_personas = get_posts(
+		// Get all personas.
+		$personas = get_posts(
 			array(
 				'post_type'      => 'persona',
-				'posts_per_page' => 5,
-				'orderby'        => 'date',
-				'order'          => 'DESC',
+				'posts_per_page' => -1,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
 			)
 		);
 		?>
 		<div class="wrap cme-personas-dashboard">
 			<h1><?php esc_html_e( 'Personas Dashboard', 'cme-personas' ); ?></h1>
 
-			<div class="welcome-panel">
-				<div class="welcome-panel-content">
-					<h2><?php esc_html_e( 'Welcome to Personas!', 'cme-personas' ); ?></h2>
-					<p class="about-description"><?php esc_html_e( 'Personas allows you to personalize content for different customer segments.', 'cme-personas' ); ?></p>
-					<div class="welcome-panel-column-container">
-						<div class="welcome-panel-column">
-							<h3><?php esc_html_e( 'Get Started', 'cme-personas' ); ?></h3>
-							<ul>
-								<li><?php printf( '<a href="%s" class="button button-primary button-hero">%s</a>', esc_url( admin_url( 'edit.php?post_type=persona' ) ), esc_html__( 'Manage Personas', 'cme-personas' ) ); ?></li>
-							</ul>
-						</div>
-						<div class="welcome-panel-column">
-							<h3><?php esc_html_e( 'Documentation', 'cme-personas' ); ?></h3>
-							<ul>
-								<li><a href="#"><?php esc_html_e( 'Using Personas', 'cme-personas' ); ?></a></li>
-								<li><a href="#"><?php esc_html_e( 'Shortcodes Reference', 'cme-personas' ); ?></a></li>
-								<li><a href="#"><?php esc_html_e( 'Developer Guide', 'cme-personas' ); ?></a></li>
-							</ul>
-						</div>
-						<div class="welcome-panel-column welcome-panel-last">
-							<h3><?php esc_html_e( 'Next Steps', 'cme-personas' ); ?></h3>
-							<ul>
-								<li><a href="<?php echo esc_url( admin_url( 'post-new.php?post_type=persona' ) ); ?>"><?php esc_html_e( 'Create a new persona', 'cme-personas' ); ?></a></li>
-								<li><a href="<?php echo esc_url( admin_url( 'post-new.php' ) ); ?>"><?php esc_html_e( 'Add personalized content to a post', 'cme-personas' ); ?></a></li>
-							</ul>
-						</div>
-					</div>
+			<!-- Personas Overview Section -->
+			<div class="cme-dashboard-section">
+				<h2><?php esc_html_e( 'Personas Overview', 'cme-personas' ); ?></h2>
+
+				<div class="cme-persona-grid">
+					<?php if ( $personas ) : ?>
+						<?php foreach ( $personas as $persona ) : ?>
+							<?php
+							// Get persona images.
+							$male_image_id          = get_post_meta( $persona->ID, 'persona_image_male', true );
+							$female_image_id        = get_post_meta( $persona->ID, 'persona_image_female', true );
+							$indeterminate_image_id = get_post_meta( $persona->ID, 'persona_image_indeterminate', true );
+
+							// Get image names.
+							$male_name          = $this->get_image_name( $male_image_id );
+							$female_name        = $this->get_image_name( $female_image_id );
+							$indeterminate_name = $this->get_image_name( $indeterminate_image_id );
+
+							// Get attributes.
+							$attributes = get_post_meta( $persona->ID, 'persona_attributes', true );
+							?>
+							<div class="cme-persona-card">
+								<div class="cme-persona-card-title"><?php echo esc_html( $persona->post_title ); ?></div>
+
+								<div class="cme-persona-images">
+									<div class="cme-persona-image">
+										<?php if ( $male_image_id ) : ?>
+											<?php echo wp_get_attachment_image( $male_image_id, 'thumbnail' ); ?>
+											<div class="cme-persona-image-name"><?php echo esc_html( $male_name ); ?></div>
+										<?php else : ?>
+											<div class="cme-persona-image-placeholder dashicons dashicons-businessman"></div>
+											<div class="cme-persona-image-name"><?php esc_html_e( 'Male', 'cme-personas' ); ?></div>
+										<?php endif; ?>
+									</div>
+
+									<div class="cme-persona-image">
+										<?php if ( $female_image_id ) : ?>
+											<?php echo wp_get_attachment_image( $female_image_id, 'thumbnail' ); ?>
+											<div class="cme-persona-image-name"><?php echo esc_html( $female_name ); ?></div>
+										<?php else : ?>
+											<div class="cme-persona-image-placeholder dashicons dashicons-businesswoman"></div>
+											<div class="cme-persona-image-name"><?php esc_html_e( 'Female', 'cme-personas' ); ?></div>
+										<?php endif; ?>
+									</div>
+
+									<div class="cme-persona-image">
+										<?php if ( $indeterminate_image_id ) : ?>
+											<?php echo wp_get_attachment_image( $indeterminate_image_id, 'thumbnail' ); ?>
+											<div class="cme-persona-image-name"><?php echo esc_html( $indeterminate_name ); ?></div>
+										<?php else : ?>
+											<div class="cme-persona-image-placeholder dashicons dashicons-admin-users"></div>
+											<div class="cme-persona-image-name"><?php esc_html_e( 'Person', 'cme-personas' ); ?></div>
+										<?php endif; ?>
+									</div>
+								</div>
+
+								<div class="cme-persona-attributes">
+									<strong><?php esc_html_e( 'Key Attributes:', 'cme-personas' ); ?></strong>
+									<?php if ( ! empty( $attributes ) ) : ?>
+										<?php echo wp_kses_post( wpautop( $attributes ) ); ?>
+									<?php else : ?>
+										<p><?php esc_html_e( 'No attributes defined.', 'cme-personas' ); ?></p>
+									<?php endif; ?>
+								</div>
+
+								<div class="cme-persona-actions">
+									<a href="<?php echo esc_url( get_edit_post_link( $persona->ID ) ); ?>" class="cme-persona-action-edit">
+										<?php esc_html_e( 'Edit', 'cme-personas' ); ?>
+									</a>
+									<a href="<?php echo esc_url( get_permalink( $persona->ID ) ); ?>" class="cme-persona-action-view">
+										<?php esc_html_e( 'View', 'cme-personas' ); ?>
+									</a>
+								</div>
+							</div>
+						<?php endforeach; ?>
+					<?php else : ?>
+						<p><?php esc_html_e( 'No personas found.', 'cme-personas' ); ?></p>
+					<?php endif; ?>
 				</div>
 			</div>
 
-			<div class="metabox-holder">
-				<div class="postbox-container" style="width:49%; float:left; margin-right: 2%;">
-					<div class="postbox">
-						<h2 class="hndle"><span><?php esc_html_e( 'At a Glance', 'cme-personas' ); ?></span></h2>
-						<div class="inside">
-							<div class="main">
-								<ul>
-									<li class="persona-count">
-										<?php
-										echo wp_kses(
-											sprintf(
-												/* translators: %s: number of personas */
-												_n( '%s Persona', '%s Personas', $persona_count, 'cme-personas' ),
-												'<span class="count">' . esc_html( number_format_i18n( $persona_count ) ) . '</span>'
-											),
-											array( 'span' => array( 'class' => array() ) )
-										);
-										?>
-									</li>
-								</ul>
-							</div>
-						</div>
-					</div>
-				</div>
+			<!-- Documentation & Management Section -->
+			<div class="cme-dashboard-section">
+				<h2><?php esc_html_e( 'Documentation & Management', 'cme-personas' ); ?></h2>
 
-				<div class="postbox-container" style="width:49%; float:left;">
-					<div class="postbox">
-						<h2 class="hndle"><span><?php esc_html_e( 'Recent Personas', 'cme-personas' ); ?></span></h2>
-						<div class="inside">
-							<?php if ( $recent_personas ) : ?>
-								<ul>
-									<?php foreach ( $recent_personas as $persona ) : ?>
-										<li>
-											<a href="<?php echo esc_url( get_edit_post_link( $persona->ID ) ); ?>">
-												<?php echo esc_html( $persona->post_title ); ?>
-											</a>
-											<span class="post-date">
-												<?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $persona->post_date ) ) ); ?>
-											</span>
-										</li>
-									<?php endforeach; ?>
-								</ul>
-							<?php else : ?>
-								<p><?php esc_html_e( 'No personas found.', 'cme-personas' ); ?></p>
-							<?php endif; ?>
-						</div>
-					</div>
+				<div class="cme-card-grid">
+					<a href="<?php echo esc_url( admin_url( 'post-new.php?post_type=persona' ) ); ?>" class="cme-card">
+						<div class="cme-card-icon dashicons dashicons-plus-alt"></div>
+						<div class="cme-card-title"><?php esc_html_e( 'Add New Persona', 'cme-personas' ); ?></div>
+						<div class="cme-card-desc"><?php esc_html_e( 'Create a new persona profile', 'cme-personas' ); ?></div>
+					</a>
+
+					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=persona' ) ); ?>" class="cme-card">
+						<div class="cme-card-icon dashicons dashicons-admin-generic"></div>
+						<div class="cme-card-title"><?php esc_html_e( 'Manage Personas', 'cme-personas' ); ?></div>
+						<div class="cme-card-desc"><?php esc_html_e( 'View and edit all personas', 'cme-personas' ); ?></div>
+					</a>
+
+					<a href="<?php echo esc_url( plugin_dir_url( CME_PERSONAS_FILE ) . 'docs/guides/PERSONAS.md' ); ?>" class="cme-card">
+						<div class="cme-card-icon dashicons dashicons-book"></div>
+						<div class="cme-card-title"><?php esc_html_e( 'Using Personas', 'cme-personas' ); ?></div>
+						<div class="cme-card-desc"><?php esc_html_e( 'Learn how to implement personas in content', 'cme-personas' ); ?></div>
+					</a>
+
+					<a href="<?php echo esc_url( plugin_dir_url( CME_PERSONAS_FILE ) . 'docs/development/' ); ?>" class="cme-card">
+						<div class="cme-card-icon dashicons dashicons-editor-code"></div>
+						<div class="cme-card-title"><?php esc_html_e( 'Developer Guide', 'cme-personas' ); ?></div>
+						<div class="cme-card-desc"><?php esc_html_e( 'Technical documentation for developers', 'cme-personas' ); ?></div>
+					</a>
 				</div>
 			</div>
 		</div>

--- a/includes/class-personas-post-types.php
+++ b/includes/class-personas-post-types.php
@@ -112,6 +112,44 @@ class Personas_Post_Types {
 			'normal',
 			'high'
 		);
+
+		add_meta_box(
+			'persona_attributes',
+			__( 'Key Attributes', 'cme-personas' ),
+			array( $this, 'render_persona_attributes_metabox' ),
+			$this->persona_post_type,
+			'normal',
+			'high'
+		);
+	}
+
+	/**
+	 * Render meta box for persona key attributes.
+	 *
+	 * @since    1.6.0
+	 * @param    \WP_Post $post  The post object.
+	 * @return   void
+	 */
+	public function render_persona_attributes_metabox( \WP_Post $post ): void {
+		wp_nonce_field( 'persona_attributes_nonce', 'persona_attributes_nonce' );
+
+		$attributes = get_post_meta( $post->ID, 'persona_attributes', true );
+
+		?>
+		<p><?php esc_html_e( 'Enter key attributes for this persona. This information will be displayed on the dashboard and can be used for future AI integration.', 'cme-personas' ); ?></p>
+		<p><?php esc_html_e( 'Markdown formatting is supported.', 'cme-personas' ); ?></p>
+
+		<?php
+		wp_editor(
+			$attributes,
+			'persona_attributes',
+			array(
+				'media_buttons' => false,
+				'textarea_rows' => 10,
+				'teeny'         => true,
+				'quicktags'     => array( 'buttons' => 'strong,em,ul,ol,li,link' ),
+			)
+		);
 	}
 
 	/**
@@ -306,6 +344,14 @@ class Personas_Post_Types {
 			$indeterminate_image_id = sanitize_text_field( wp_unslash( $_POST['persona_image_indeterminate'] ) );
 			update_post_meta( $post_id, 'persona_image_indeterminate', $indeterminate_image_id );
 			// Media taxonomy functionality has been removed.
+		}
+
+		// Save persona attributes.
+		if ( isset( $_POST['persona_attributes_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['persona_attributes_nonce'] ) ), 'persona_attributes_nonce' ) ) {
+			if ( isset( $_POST['persona_attributes'] ) ) {
+				$attributes = wp_kses_post( wp_unslash( $_POST['persona_attributes'] ) );
+				update_post_meta( $post_id, 'persona_attributes', $attributes );
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR implements a comprehensive redesign of the Personas dashboard:

## Features

- **Added Key Attributes Field**: Created a custom meta field for persona attributes with markdown support
- **Modern Card-Based Layout**: Redesigned dashboard with visually appealing card grid
- **Persona Avatar Display**: Show all three gender variants with names extracted from filenames
- **Attributes Display**: Display key persona attributes from the new meta field
- **Documentation & Management Section**: Added cards for quick access to docs and management tools
- **Modern CSS**: Implemented modern styling that matches the Cruises dashboard

## Screenshots
(Screenshots will need to be added manually)

## Testing
- Verify that the new key attributes field works correctly
- Test the dashboard with and without persona data
- Check that image names are properly extracted
- Ensure responsive layout works on different screen sizes