### PR TITLE
fix: ensure persona attributes field is empty on new post creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
+- Empty field for persona attributes when creating a new persona.
+- Default text showing in the attributes field on first load.
 
+### Changed
 - Refactored plugin architecture to follow Single Responsibility Principle:
   - Split `class-persona-manager.php` into specialized components:
     - `class-personas-detector.php`: Handles persona detection from various sources

--- a/includes/class-personas-post-types.php
+++ b/includes/class-personas-post-types.php
@@ -133,7 +133,11 @@ class Personas_Post_Types {
 	public function render_persona_attributes_metabox( \WP_Post $post ): void {
 		wp_nonce_field( 'persona_attributes_nonce', 'persona_attributes_nonce' );
 
-		$attributes = get_post_meta( $post->ID, 'persona_attributes', true );
+		// Get attributes, ensure new posts start with empty attributes.
+		$attributes = '';
+		if ( 'auto-draft' !== $post->post_status ) {
+			$attributes = get_post_meta( $post->ID, 'persona_attributes', true );
+		}
 
 		?>
 		<p><?php esc_html_e( 'Enter key attributes for this persona. This information will be displayed on the dashboard and can be used for future AI integration.', 'cme-personas' ); ?></p>


### PR DESCRIPTION
This PR fixes an issue where the Key Attributes field was showing previously saved content when creating a new persona.\n\n- Detects when a post is being created (auto-draft) and ensures the attributes field starts empty\n- Updates Yoda condition to match coding standards\n- Adds period to inline comment for linting compliance\n- Updates CHANGELOG.md to document the fix\n\nWith this change, users will see an empty field when creating a new persona rather than content from a previously edited persona.