### PR TITLE
fix: improve handling of empty attributes field and TinyMCE editor issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Empty field for persona attributes when creating a new persona.
-- Default text showing in the attributes field on first load.
+
+- Fixed empty and default text issues with the persona attributes field:
+  - Ensures field is empty when creating a new persona
+  - Handles existing posts with no attributes data correctly
+  - Prevents HTML markup from appearing in the editor
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Empty field for persona attributes when creating a new persona.
+- Default text showing in the attributes field on first load.
+
 ### Changed
 
 - Refactored plugin architecture to follow Single Responsibility Principle:
@@ -28,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed legacy files and eliminated backward compatibility for cleaner architecture
   - Applied consistent class naming throughout the codebase
 
-+## [1.5.4] - 2025-03-15
+## [1.5.4] - 2025-03-15
 
 ### Fixed
 

--- a/includes/class-personas-post-types.php
+++ b/includes/class-personas-post-types.php
@@ -133,7 +133,11 @@ class Personas_Post_Types {
 	public function render_persona_attributes_metabox( \WP_Post $post ): void {
 		wp_nonce_field( 'persona_attributes_nonce', 'persona_attributes_nonce' );
 
-		$attributes = get_post_meta( $post->ID, 'persona_attributes', true );
+		// Get attributes, ensure new posts start with empty attributes.
+		$attributes = '';
+		if ( 'auto-draft' !== $post->post_status ) {
+			$attributes = get_post_meta( $post->ID, 'persona_attributes', true );
+		}
 
 		?>
 		<p><?php esc_html_e( 'Enter key attributes for this persona. This information will be displayed on the dashboard and can be used for future AI integration.', 'cme-personas' ); ?></p>

--- a/includes/class-personas-post-types.php
+++ b/includes/class-personas-post-types.php
@@ -133,11 +133,9 @@ class Personas_Post_Types {
 	public function render_persona_attributes_metabox( \WP_Post $post ): void {
 		wp_nonce_field( 'persona_attributes_nonce', 'persona_attributes_nonce' );
 
-		// Get attributes, ensure new posts start with empty attributes.
-		$attributes = '';
-		if ( 'auto-draft' !== $post->post_status ) {
-			$attributes = get_post_meta( $post->ID, 'persona_attributes', true );
-		}
+		// Get attributes, ensure empty string is used when no saved data exists.
+		$attributes = get_post_meta( $post->ID, 'persona_attributes', true );
+		$attributes = ( empty( $attributes ) && ! is_numeric( $attributes ) ) ? '' : $attributes;
 
 		?>
 		<p><?php esc_html_e( 'Enter key attributes for this persona. This information will be displayed on the dashboard and can be used for future AI integration.', 'cme-personas' ); ?></p>
@@ -152,6 +150,15 @@ class Personas_Post_Types {
 				'textarea_rows' => 10,
 				'teeny'         => true,
 				'quicktags'     => array( 'buttons' => 'strong,em,ul,ol,li,link' ),
+				'tinymce'       => array(
+					'init_instance_callback' => 'function(editor) {
+						editor.on("focus", function() {
+							if (editor.getContent() === "<p></p>") {
+								editor.setContent("");
+							}
+						});
+					}',
+				),
 			)
 		);
 	}


### PR DESCRIPTION
This PR fixes issues with the Key Attributes field in the persona editor:\n\n- Improved handling of empty data with a proper check that ensures an empty field is shown when no data exists\n- Added TinyMCE initialization callback to clear default <p></p> content on editor focus\n- Updated CHANGELOG with more comprehensive description of the fixes\n\nThese changes ensure the Key Attributes field works correctly in both new and existing posts, preventing the HTML markup from appearing in the editor and ensuring a clean editing experience.