### PR TITLE
fix: move persona attributes to use standard post content editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed empty and default text issues with the persona attributes field:
-  - Ensures field is empty when creating a new persona
-  - Handles existing posts with no attributes data correctly
-  - Prevents HTML markup from appearing in the editor
+- Fixed persona attributes TinyMCE formatting issues:
+  - Moved attributes from custom meta field to standard post content
+  - Leverages WordPress core editor instead of custom implementation
+  - Eliminates HTML markup issues in the editor
+  - Properly handles empty fields for new posts
 - Synchronized repository branches to ensure consistent development workflow
 
 ### Changed

--- a/includes/class-personas-dashboard.php
+++ b/includes/class-personas-dashboard.php
@@ -185,8 +185,8 @@ class Personas_Dashboard {
 							$female_name        = $this->get_image_name( $female_image_id );
 							$indeterminate_name = $this->get_image_name( $indeterminate_image_id );
 
-							// Get attributes.
-							$attributes = get_post_meta( $persona->ID, 'persona_attributes', true );
+							// Get attributes from post content.
+							$attributes = $persona->post_content;
 							?>
 							<div class="cme-persona-card">
 								<h2 class="cme-persona-card-title"><?php echo esc_html( $persona->post_title ); ?></h2>

--- a/includes/class-personas-post-types.php
+++ b/includes/class-personas-post-types.php
@@ -86,7 +86,7 @@ class Personas_Post_Types {
 				'show_in_nav_menus' => true,
 				'show_in_rest'      => true,
 				'menu_icon'         => 'dashicons-groups',
-				'supports'          => array( 'title', 'excerpt', 'thumbnail' ),
+				'supports'          => array( 'title', 'excerpt', 'thumbnail', 'editor' ),
 				'has_archive'       => false,
 				'rewrite'           => array( 'slug' => 'persona' ),
 				'query_var'         => true,
@@ -113,14 +113,7 @@ class Personas_Post_Types {
 			'high'
 		);
 
-		add_meta_box(
-			'persona_attributes',
-			__( 'Key Attributes', 'cme-personas' ),
-			array( $this, 'render_persona_attributes_metabox' ),
-			$this->persona_post_type,
-			'normal',
-			'high'
-		);
+		// Key Attributes are now handled by the main editor.
 	}
 
 	/**
@@ -357,12 +350,6 @@ class Personas_Post_Types {
 			// Media taxonomy functionality has been removed.
 		}
 
-		// Save persona attributes.
-		if ( isset( $_POST['persona_attributes_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['persona_attributes_nonce'] ) ), 'persona_attributes_nonce' ) ) {
-			if ( isset( $_POST['persona_attributes'] ) ) {
-				$attributes = wp_kses_post( wp_unslash( $_POST['persona_attributes'] ) );
-				update_post_meta( $post_id, 'persona_attributes', $attributes );
-			}
-		}
+		// Attributes are now handled by the main post_content field.
 	}
 }

--- a/scripts/migrate-attributes-to-post-content.php
+++ b/scripts/migrate-attributes-to-post-content.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Migration script to move persona attributes from meta field to post content.
+ *
+ * This script should be run once after updating the plugin to move existing
+ * persona attributes from the custom meta field to the standard post_content field.
+ *
+ * Usage:
+ * 1. Place this file in your WordPress root directory
+ * 2. Run via WP-CLI: wp eval-file migrate-attributes-to-post-content.php
+ * 3. Or run via browser (with proper access control)
+ *
+ * @package CME_Personas
+ */
+
+// Verify this is being run in WordPress context.
+if ( ! defined( 'ABSPATH' ) && ! defined( 'WP_CLI' ) ) {
+    // Bootstrap WordPress.
+    $wp_load_path = dirname( __FILE__ ) . '/wp-load.php';
+    if ( file_exists( $wp_load_path ) ) {
+        require_once $wp_load_path;
+    } else {
+        die( 'Cannot find WordPress installation. Please run this from the WordPress root directory.' );
+    }
+}
+
+// Verify user has permission.
+if ( ! current_user_can( 'manage_options' ) && ! defined( 'WP_CLI' ) ) {
+    die( 'You do not have sufficient permissions to run this script.' );
+}
+
+/**
+ * Migrate all persona attributes from meta field to post content.
+ */
+function migrate_persona_attributes() {
+    $migrated = 0;
+    $skipped = 0;
+    $errors = 0;
+
+    // Get all persona posts.
+    $personas = get_posts(
+        array(
+            'post_type'      => 'persona',
+            'posts_per_page' => -1,
+            'post_status'    => 'any',
+        )
+    );
+
+    if ( empty( $personas ) ) {
+        log_message( 'No personas found to migrate.' );
+        return;
+    }
+
+    log_message( sprintf( 'Found %d personas to process.', count( $personas ) ) );
+
+    foreach ( $personas as $persona ) {
+        // Skip if the post content is not empty, to avoid overwriting data.
+        if ( ! empty( $persona->post_content ) ) {
+            log_message( sprintf( 'Skipping persona #%d "%s" - post content is not empty.', $persona->ID, $persona->post_title ) );
+            $skipped++;
+            continue;
+        }
+
+        // Get attributes from meta.
+        $attributes = get_post_meta( $persona->ID, 'persona_attributes', true );
+
+        // Skip if no attributes found.
+        if ( empty( $attributes ) && ! is_numeric( $attributes ) ) {
+            log_message( sprintf( 'Skipping persona #%d "%s" - no attributes found.', $persona->ID, $persona->post_title ) );
+            $skipped++;
+            continue;
+        }
+
+        // Update post content.
+        $updated_post = array(
+            'ID'           => $persona->ID,
+            'post_content' => $attributes,
+        );
+
+        $result = wp_update_post( $updated_post );
+
+        if ( is_wp_error( $result ) ) {
+            log_message( sprintf( 'Error updating persona #%d "%s": %s', $persona->ID, $persona->post_title, $result->get_error_message() ) );
+            $errors++;
+        } else {
+            log_message( sprintf( 'Successfully migrated attributes for persona #%d "%s".', $persona->ID, $persona->post_title ) );
+            $migrated++;
+        }
+    }
+
+    log_message( sprintf( 'Migration complete. %d personas migrated, %d skipped, %d errors.', $migrated, $skipped, $errors ) );
+}
+
+/**
+ * Log a message to the appropriate output.
+ *
+ * @param string $message The message to log.
+ */
+function log_message( $message ) {
+    if ( defined( 'WP_CLI' ) ) {
+        WP_CLI::line( $message );
+    } else {
+        echo $message . '<br>';
+    }
+}
+
+// Run the migration.
+log_message( 'Starting migration of persona attributes to post content...' );
+migrate_persona_attributes();
+log_message( 'Done.' );


### PR DESCRIPTION
This PR fixes the TinyMCE formatting issues with the Key Attributes field by:\n\n- Moving attributes data from custom meta field to standard WordPress post_content\n- Enabling the editor in post type registration\n- Updating the dashboard to read from post_content instead of meta field\n- Removing the custom attributes meta box\n- Adding proper full-stops to inline comments for linting compliance\n\nThis approach leverages WordPress core functionality instead of a custom implementation, which eliminates HTML markup issues and properly handles empty fields.\n\n## Migration Script\n\nA migration script () is included to help site owners migrate existing data from the meta field to post content. The script can be run via WP-CLI or browser and includes safety checks to avoid overwriting existing content.